### PR TITLE
Update the documentation for the initialization syntax + minor fixes

### DIFF
--- a/docs/src/manuals/inference/initialization.md
+++ b/docs/src/manuals/inference/initialization.md
@@ -6,6 +6,65 @@ In certain models, after completing the model specification step and moving on t
 @initialization
 ```
 
+The syntax for the `@initialization` macro is similar to the `@constraints` and `@meta` macro. An example is shown below:
+
+```@example init-example
+using RxInfer
+
+@model function submodel(z, x) 
+    t := x + 1
+    z ~ Normal(mean = t, var = 1.0)
+end 
+
+@model function mymodel(y)
+    x ~ Normal(mean = 0.0, var = 1.0)
+    z ~ submodel(x = x)
+    y ~ Normal(mean = z, var = 1.0)
+end
+
+@initialization begin
+    # Initialize the marginal for the variable x
+    q(x) = vague(NormalMeanVariance)
+
+    # Initialize the message for the variable z
+    μ(z) = vague(NormalMeanVariance)
+
+    # Specify the initialization for a submodel of type `submodel`
+    for init in submodel
+        q(t) = vague(NormalMeanVariance)
+    end
+
+    # Specify the initialization for a submodel of type `submodel` with a specific index
+    for init in (submodel, 1)
+        q(t) = vague(NormalMeanVariance)
+    end
+end
+```
+
+Similar to the `@constraints` macro, the `@initialization` macro also supports function definitions:
+
+```@example init-example
+@initialization function my_init()
+    # Initialize the marginal for the variable x
+    q(x) = vague(NormalMeanVariance)
+
+    # Initialize the message for the variable z
+    μ(z) = vague(NormalMeanVariance)
+
+    # Specify the initialization for a submodel of type `submodel`
+    for init in submodel
+        q(t) = vague(NormalMeanVariance)
+    end
+
+    # Specify the initialization for a submodel of type `submodel` with a specific index
+    for init in (submodel, 1)
+        q(t) = vague(NormalMeanVariance)
+    end
+end
+```
+
+The result of the initialization macro can be passed to the [`infer`](@ref) function with a keyword argument called [`initialization`](@ref user-guide-inference-execution).
+
 ## Part 1. Framing the problem 
 
 John has recently acquired a new car and is keenly interested in its `fuel consumption` rate. He holds the belief that this rate follows a linear relationship with the variable `speed`. To validate this hypothesis, he plans to conduct tests by driving his car on the urban roads close to his home, recording both the `fuel consumption` and `speed` data. To ascertain the fuel consumption rate, John has opted for Bayesian linear regression as his analytical method.

--- a/docs/src/manuals/migration-guide-v2-v3.md
+++ b/docs/src/manuals/migration-guide-v2-v3.md
@@ -63,7 +63,7 @@ infer(
 )
 ```
 
-### Multiple dispatch is no long supported
+### Multiple dispatch is no longer supported
 
 Due to the previous change, it is not possible to use multiple dispatch for model function definitions. In other words, type constraints for model arguments are ignored because Julia does not support multiple dispatch for keyword arguments.
 
@@ -138,61 +138,5 @@ nothing #hide
 
 ## Initialization
 
-Also read the [Initialization](@ref initialization) guide.
-
-Initialization of messages and marginals to kickstart the inference procedure was previously done with the `initmessages` and `initmarginals` keyword. With the introduction of a nested model specificiation in the `@model` macro, we now need a more specific way to initialize messages and marginals. This is done with the new [`@initialization`](@ref) macro. The syntax for the `@initialization` macro is similar to the `@constraints` and `@meta` macro. An example is shown below:
-
-```@example migration-guide
-@model function submodel(z, x) 
-    t := x + 1
-    z ~ Normal(mean = t, var = 1.0)
-end 
-
-@model function mymodel(y)
-    x ~ Normal(mean = 0.0, var = 1.0)
-    z ~ submodel(x = x)
-    y ~ Normal(mean = z, var = 1.0)
-end
-
-@initialization begin
-    # Initialize the marginal for the variable x
-    q(x) = vague(NormalMeanVariance)
-
-    # Initialize the message for the variable z
-    μ(z) = vague(NormalMeanVariance)
-
-    # Specify the initialization for a submodel of type `submodel`
-    for init in submodel
-        q(t) = vague(NormalMeanVariance)
-    end
-
-    # Specify the initialization for a submodel of type `submodel` with a specific index
-    for init in (submodel, 1)
-        q(t) = vague(NormalMeanVariance)
-    end
-end
-```
-
-Similar to the `@constraints` macro, the `@initialization` macro also supports function definitions:
-
-```@example migration-guide
-@initialization function my_init()
-    # Initialize the marginal for the variable x
-    q(x) = vague(NormalMeanVariance)
-
-    # Initialize the message for the variable z
-    μ(z) = vague(NormalMeanVariance)
-
-    # Specify the initialization for a submodel of type `submodel`
-    for init in submodel
-        q(t) = vague(NormalMeanVariance)
-    end
-
-    # Specify the initialization for a submodel of type `submodel` with a specific index
-    for init in (submodel, 1)
-        q(t) = vague(NormalMeanVariance)
-    end
-end
-```
-
-The result of the initialization macro can be passed to the inference function with keyword argument `initialization`.
+Initialization of messages and marginals to kickstart the inference procedure was previously done with the `initmessages` and `initmarginals` keyword. With the introduction of a nested model specificiation in the `@model` macro, we now need a more specific way to initialize messages and marginals. This is done with the new [`@initialization`](@ref) macro. 
+Read more about the new syntax in the [Initialization](@ref initialization) guide.


### PR DESCRIPTION
This PR makes the documentation for RxInfer better by:
- Moving important details about initializing nested models to the main guide. The migration guide now points to this main guide.
- Adding more info about how RxInfer handles missing values.
- Making some small fixes.

Fixes #298