### PR TITLE
Create a separate CI action for formatting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,14 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  format: 
-    name: Julia Formatter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-      - uses: julia-actions/cache@v1         
-      - run: make lint
   paper:
     name: Paper Preview
     runs-on: ubuntu-latest
@@ -46,7 +38,6 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.version, 'nightly') }}
-    needs: format
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +69,6 @@ jobs:
   examples:
     name: Examples
     runs-on: ubuntu-latest
-    needs: format
     permissions:
       contents: write
     steps:
@@ -99,7 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - test
-      - format
       - examples
     permissions:
       contents: write

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,13 @@
+name: Format suggestions
+on:
+  pull_request:
+    # this argument is not required if you don't use the `suggestion-label` input
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
+jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/julia-format@v3
+        with:
+          version: '1' 
+          suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs


### PR DESCRIPTION
This pull request introduces the `Format.yml` action, which automatically generates PRs for formatting suggestions. It also removes the explicit requirement for the code to be perfectly formatted. I believe that as we expand our pool of collaborators, this approach is preferable to banning PR due to formatting issues.