### PR TITLE
Remove Forney-style prefixes from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 `RxInfer.jl` is a Julia package for automatic Bayesian inference on a factor graph with reactive message passing.
 
-Given a probabilistic model, RxInfer allows for an efficient message-passing based Bayesian inference. It uses the model structure to generate an algorithm that consists of a sequence of local computations on a Forney-style factor graph (FFG) representation of the model.
+Given a probabilistic model, RxInfer allows for an efficient message-passing based Bayesian inference. It uses the model structure to generate an algorithm that consists of a sequence of local computations on a factor graph representation of the model.
 
 ### Performance and scalability
 
@@ -131,7 +131,7 @@ Now let's see how to specify this model using [GraphPPL's package](https://githu
 end
 ```
 
-In short, the `@model` macro converts a textual description of a probabilistic model into a corresponding [Factor Graph](https://en.wikipedia.org/wiki/Factor_graph) (FG). In the example above, the $\theta \sim \mathrm{Beta}(a, b)$ expression creates latent variable $θ$ and assigns it as an output of $\mathrm{Beta}$ node in the corresponding FFG. The `~` operation can be understood as _"is modelled by"_. Next, we model each data point `y[i]` as $\mathrm{Bernoulli}$ distribution with $\theta$ as its parameter.
+In short, the `@model` macro converts a textual description of a probabilistic model into a corresponding [Factor Graph](https://en.wikipedia.org/wiki/Factor_graph) (FG). In the example above, the $\theta \sim \mathrm{Beta}(a, b)$ expression creates latent variable $θ$ and assigns it as an output of $\mathrm{Beta}$ node in the corresponding factor graph. The `~` operation can be understood as _"is modelled by"_. Next, we model each data point `y[i]` as $\mathrm{Bernoulli}$ distribution with $\theta$ as its parameter.
 
 > [!TIP]
 > Alternatively, we could use the broadcasting operation:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ RxInfer
 
 *Julia package for automatic Bayesian inference on a factor graph with reactive message passing.*
 
-Given a probabilistic model, RxInfer allows for an efficient message-passing based Bayesian inference. It uses the model structure to generate an algorithm that consists of a sequence of local computations on a Forney-style factor graph (FFG) representation of the model. RxInfer.jl has been designed with a focus on efficiency, scalability and maximum performance for running inference with [reactive message passing](https://github.com/ReactiveBayes/ReactiveMP.jl).
+Given a probabilistic model, RxInfer allows for an efficient message-passing based Bayesian inference. It uses the model structure to generate an algorithm that consists of a sequence of local computations on a factor graph representation of the model. RxInfer.jl has been designed with a focus on efficiency, scalability and maximum performance for running inference with [reactive message passing](https://github.com/ReactiveBayes/ReactiveMP.jl).
 
 ## Why RxInfer
 

--- a/docs/src/manuals/inference/initialization.md
+++ b/docs/src/manuals/inference/initialization.md
@@ -143,7 +143,7 @@ After running the inference procedure an error appears, which prompts him to _in
 
 ## Part 2. Why and What to initialize
 
-Before delving too deeply into the details, it's important to understand that RxInfer constructs a factorized representation of your model using a Forney Style Factor Graph (FFG). In this structure, inference is executed through message passing.
+Before delving too deeply into the details, it's important to understand that RxInfer constructs a factorized representation of your model using a factor graph. In this structure, inference is executed through message passing.
 
 A challenge arises when RxInfer generates the FFG representation with structural loops in certain parts of the graph. These loops indicate that a message or marginal within the loop depends not only on its prior but also on itself. Consequently, proper initialization is crucial for initiating the inference process. Two general rules of thumb guide this initialization, although the intricate details are beyond the scope of this tutorial:
 
@@ -159,9 +159,9 @@ Identifying loops is currently a manual process, as the current version of RxInf
 
 However, once you receive the message `Variables [x, y, z] have not been updated after an update event`, it is a good indication that there is a loop in your model. If you see this message, you should check your model for loops and try to initialize the messages and/or marginals that are part of the loop.
 
-### Deriving FFG and identifying the loops
+### Deriving factor graph and identifying the loops
 
-John proceeds to derive the FFG for his problem where he identifies where the loops are:
+John proceeds to derive the factor graph for his problem where he identifies where the loops are:
 
 ![Addons_messages](../../assets/img/linear_regresion_model.png)
 

--- a/examples/basic_examples/Coin Toss Model.ipynb
+++ b/examples/basic_examples/Coin Toss Model.ipynb
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# GraphPPL.jl export `@model` macro for model specification\n",
-    "# It accepts a regular Julia function and builds an FFG under the hood\n",
+    "# It accepts a regular Julia function and builds a factor graph under the hood\n",
     "@model function coin_model(y, a, b)\n",
     "\n",
     "    # We endow θ parameter of our model with \"a\" prior\n",


### PR DESCRIPTION
To alleviate confusion experienced by new users and developers, I have removed Forney-style prefixes from the documentation and examples, retaining only “factor graph” for clarity.