### PR TITLE
Add UnfactorizedData

### DIFF
--- a/src/inference/batch.jl
+++ b/src/inference/batch.jl
@@ -175,7 +175,7 @@ function batch_inference(;
         # But only if the data has missing values in it
     elseif isnothing(predictvars) && !isnothing(data)
         predictoption = iterations isa Number ? KeepEach() : KeepLast()
-        predictvars = Dict(variable => predictoption for (variable, value) in pairs(data) if inference_check_dataismissing(value))
+        predictvars = Dict(variable => predictoption for (variable, value) in pairs(data) if inference_check_dataismissing(get_data(value)))
         # If both `predictvar` and `data` are specified we double check if there are some entries in the `predictvars`
         # which are not specified in the `data` and inject them
         # We do the same the other way around for the `data` entries which are not specified in the `predictvars`
@@ -297,7 +297,7 @@ function batch_inference(;
             end
             inference_invoke_callback(callbacks, :before_data_update, fmodel, data)
             for (key, value) in fdata
-                update!(cacheddatavars[key], value)
+                update!(cacheddatavars[key], get_data(value))
             end
             inference_invoke_callback(callbacks, :after_data_update, fmodel, data)
 

--- a/src/inference/streaming.jl
+++ b/src/inference/streaming.jl
@@ -523,7 +523,7 @@ function streaming_inference(;
             error(lazy"`$(_autoupdate_data_handler_key)` is present both in the `data` and in the `autoupdates`.")
         end
     end
-    _condition_on = merge_data_handlers(create_deffered_data_handlers(datavarnames), autoupdates_data_handlers(autoupdates))
+    _condition_on = merge_data_handlers(create_deferred_data_handlers(datavarnames), autoupdates_data_handlers(autoupdates))
 
     inference_invoke_callback(callbacks, :before_model_creation)
     fmodel = create_model(_model | _condition_on)

--- a/test/model/model_construction_tests.jl
+++ b/test/model/model_construction_tests.jl
@@ -58,14 +58,14 @@ end
     @test create_model(conditioned) isa ProbabilisticModel
 end
 
-@testitem "create_deffered_data_handlers" begin
-    import RxInfer: create_deffered_data_handlers, DeferredDataHandler
+@testitem "create_deferred_data_handlers" begin
+    import RxInfer: create_deferred_data_handlers, DeferredDataHandler
 
-    @testset "Creating deffered labels from tuple of symbols" begin
-        @test create_deffered_data_handlers((:x, :y)) === (x = DeferredDataHandler(), y = DeferredDataHandler())
+    @testset "Creating deferred labels from tuple of symbols" begin
+        @test create_deferred_data_handlers((:x, :y)) === (x = DeferredDataHandler(), y = DeferredDataHandler())
     end
 
-    @testset "Creating deffered labels from array of symbols" begin
-        @test create_deffered_data_handlers([:x, :y]) == Dict(:x => DeferredDataHandler(), :y => DeferredDataHandler())
+    @testset "Creating deferred labels from array of symbols" begin
+        @test create_deferred_data_handlers([:x, :y]) == Dict(:x => DeferredDataHandler(), :y => DeferredDataHandler())
     end
 end


### PR DESCRIPTION
Adds and exports `UnfactorizedData`. This can be used to override the default factorization of data variables. An example of this can be found in the tests, where we manually specify a factorization over data variables to fix the issue in #355 with the Transition node.