### PR TITLE
Simplify model definition in kalman filter example

### DIFF
--- a/examples/basic_examples/Kalman filtering and smoothing.ipynb
+++ b/examples/basic_examples/Kalman filtering and smoothing.ipynb
@@ -1546,7 +1546,7 @@
    "outputs": [],
    "source": [
     "@model function rotate_ssm(y, x0, A, B, Q, P)\n",
-    "    x_prior ~ MvNormalMeanCovariance(mean(x0), cov(x0))\n",
+    "    x_prior ~ x0\n",
     "    x_prev = x_prior\n",
     "    \n",
     "    for i in 1:length(y)\n",
@@ -7006,7 +7006,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.2",
+   "display_name": "Julia 1.10.5",
    "language": "julia",
    "name": "julia-1.10"
   },
@@ -7014,7 +7014,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.2"
+   "version": "1.10.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For some reason we missed this when refactoring the examples. 