### PR TITLE
Dev node in a rule

### DIFF
--- a/docs/src/manuals/customization/custom-node.md
+++ b/docs/src/manuals/customization/custom-node.md
@@ -325,6 +325,8 @@ In some advanced scenarios, you might need access to the node object itself with
 Here's how to implement a rule with node access. First we define a custom node and a simple model that uses this node:
 
 ```@example custom-node-node-in-a-rule
+using RxInfer
+
 struct MyExperimentalNode end
 
 @node MyExperimentalNode Stochastic [ out, θ ]


### PR DESCRIPTION
This pull request introduces experimental functionality for custom nodes in `RxInfer`, allowing access to node objects within message passing rules. This feature is intended for advanced scenarios and comes with performance and global state considerations.

Key changes include:

### Experimental Features

* Added a warning about the experimental nature of the new functionality and its potential changes in future releases.

### Node Access in Rules

* Introduced the ability to pass node references to rules, enabling inspection of the current state of other variables, implementation of complex message passing schemes, and experimentation with custom inference algorithms.
* Provided an example of how to define a custom node and enable node reference passing for it.
* Demonstrated the use of the `getnode()` function to access the node object within a rule.

### Performance and Global State Considerations

* Added notes on the performance impact and global state implications of enabling node reference passing, advising caution when using this feature in production code.