### PR TITLE
Split show for benchmarkcallbacks

### DIFF
--- a/docs/src/manuals/debugging.md
+++ b/docs/src/manuals/debugging.md
@@ -264,6 +264,7 @@ The `RxInferBenchmarkCallbacks` structure collects timestamps at various stages 
 
 ```@docs
 RxInferBenchmarkCallbacks
+RxInfer.get_benchmark_stats
 ```
 
 This information can be used to:

--- a/src/inference/benchmarkcallbacks.jl
+++ b/src/inference/benchmarkcallbacks.jl
@@ -96,7 +96,22 @@ end
 
 prettytime(s) = s
 
-function __get_benchmark_stats(callbacks::RxInferBenchmarkCallbacks)
+"""
+    get_benchmark_stats(callbacks::RxInferBenchmarkCallbacks)
+
+Returns a matrix containing benchmark statistics for different operations in the inference process.
+The matrix contains the following columns:
+1. Operation name (String)
+2. Minimum time (Float64)
+3. Maximum time (Float64)
+4. Mean time (Float64)
+5. Median time (Float64)
+6. Standard deviation (Float64)
+
+Each row represents a different operation (model creation, inference, iteration, autostart).
+Times are in nanoseconds.
+"""
+function get_benchmark_stats(callbacks::RxInferBenchmarkCallbacks)
     model_creation_time = callbacks.after_model_creation_ts .- callbacks.before_model_creation_ts
     stats_to_show = [("Model creation", model_creation_time)]
     inference_time = callbacks.after_inference_ts .- callbacks.before_inference_ts
@@ -132,7 +147,7 @@ function Base.show(io::IO, callbacks::RxInferBenchmarkCallbacks)
 
     print(io, "RxInfer inference benchmark statistics: $(length(callbacks.before_model_creation_ts)) evaluations \n")
 
-    data = __get_benchmark_stats(callbacks)
+    data = get_benchmark_stats(callbacks)
     hl_v = Highlighter((data, i, j) -> (j == 3) && (data[i, j] > 10 * data[i, j - 1]), crayon"red bold")
     pretty_table(io, data; formatters = (s, i, j) -> prettytime(s), header = header, header_crayon = crayon"yellow bold", tf = tf_unicode_rounded, highlighters = hl_v)
 end

--- a/src/inference/benchmarkcallbacks.jl
+++ b/src/inference/benchmarkcallbacks.jl
@@ -96,15 +96,7 @@ end
 
 prettytime(s) = s
 
-function Base.show(io::IO, callbacks::RxInferBenchmarkCallbacks)
-    if isempty(callbacks)
-        return nothing
-    end
-
-    header = (["Operation", "Min", "Max", "Mean", "Median", "Std"],)
-
-    print(io, "RxInfer inference benchmark statistics: $(length(callbacks.before_model_creation_ts)) evaluations \n")
-
+function __get_benchmark_stats(callbacks::RxInferBenchmarkCallbacks)
     model_creation_time = callbacks.after_model_creation_ts .- callbacks.before_model_creation_ts
     stats_to_show = [("Model creation", model_creation_time)]
     inference_time = callbacks.after_inference_ts .- callbacks.before_inference_ts
@@ -128,6 +120,19 @@ function Base.show(io::IO, callbacks::RxInferBenchmarkCallbacks)
         data[i, 5] = convert(Float64, median(time))
         data[i, 6] = convert(Float64, std(time))
     end
+    return data
+end
+
+function Base.show(io::IO, callbacks::RxInferBenchmarkCallbacks)
+    if isempty(callbacks)
+        return nothing
+    end
+
+    header = (["Operation", "Min", "Max", "Mean", "Median", "Std"],)
+
+    print(io, "RxInfer inference benchmark statistics: $(length(callbacks.before_model_creation_ts)) evaluations \n")
+
+    data = __get_benchmark_stats(callbacks)
     hl_v = Highlighter((data, i, j) -> (j == 3) && (data[i, j] > 10 * data[i, j - 1]), crayon"red bold")
     pretty_table(io, data; formatters = (s, i, j) -> prettytime(s), header = header, header_crayon = crayon"yellow bold", tf = tf_unicode_rounded, highlighters = hl_v)
 end

--- a/test/inference/inference_tests.jl
+++ b/test/inference/inference_tests.jl
@@ -1076,6 +1076,15 @@ end
         @test length(last(callbacks.after_iteration_ts)) == 10
     end
 
+    stats = RxInfer.__get_benchmark_stats(callbacks)
+    for line in eachrow(stats)
+        @test line[2] > 0.0
+        @test line[3] > line[2]
+        @test line[2] < line[4] < line[3]
+        @test line[2] < line[5] < line[3]
+        @test !isnan(line[6])
+    end
+
     @model function kalman_filter(x_prev_mean, x_prev_var, τ_shape, τ_rate, y)
         x_prev ~ Normal(mean = x_prev_mean, variance = x_prev_var)
         τ ~ Gamma(shape = τ_shape, rate = τ_rate)

--- a/test/inference/inference_tests.jl
+++ b/test/inference/inference_tests.jl
@@ -1076,7 +1076,7 @@ end
         @test length(last(callbacks.after_iteration_ts)) == 10
     end
 
-    stats = RxInfer.__get_benchmark_stats(callbacks)
+    stats = RxInfer.get_benchmark_stats(callbacks)
     for line in eachrow(stats)
         @test line[2] > 0.0
         @test line[3] > line[2]


### PR DESCRIPTION
Now exposes `__get_benchmark_stats` that exports the matrix of data to show. This can be called to gather the benchmark statistics in a julia friendly way.
