### PR TITLE
GammaShapeScale - changed the dispatch version of default_parametrization for Gamma 

### DIFF
--- a/src/model/graphppl.jl
+++ b/src/model/graphppl.jl
@@ -262,9 +262,10 @@ GraphPPL.interface_aliases(::ReactiveMPGraphPPLBackend, ::Type{MvNormal}) = Grap
 
 GraphPPL.factor_alias(::ReactiveMPGraphPPLBackend, ::Type{Gamma}, ::GraphPPL.StaticInterfaces{(:α, :θ)}) = ExponentialFamily.GammaShapeScale
 GraphPPL.factor_alias(::ReactiveMPGraphPPLBackend, ::Type{Gamma}, ::GraphPPL.StaticInterfaces{(:α, :β)}) = ExponentialFamily.GammaShapeRate
-GraphPPL.default_parametrization(::ReactiveMPGraphPPLBackend, ::GraphPPL.Atomic, ::Type{Gamma}, rhs) = error(
-    "`Gamma` cannot be constructed without keyword arguments. Use `Gamma(shape = ..., rate = ...)` or `Gamma(shape = ..., scale = ...)`."
-)
+GraphPPL.default_parametrization(backend::ReactiveMPGraphPPLBackend, nodetype::GraphPPL.Atomic, factor::Type{Gamma}, rhs) = begin
+     @warn "'Gamma' and 'GammaShapeScale' without keywords are constructed with parameters (Shape, Scale)."
+     return GraphPPL.default_parametrization(backend, nodetype, ReactiveMP.inputinterfaces(factor), factor, rhs) 
+end
 
 GraphPPL.interface_aliases(::ReactiveMPGraphPPLBackend, ::Type{Gamma}) = GraphPPL.StaticInterfaceAliases((
     (:a, :α), (:shape, :α), (:β⁻¹, :θ), (:scale, :θ), (:θ⁻¹, :β), (:rate, :β)


### PR DESCRIPTION
Attempt to solve #468 :
I changed the dispatch version of default_parametrization for Gamma to include a warning and then use the fallback version with lookup in ReactiveMP.
`GraphPPL.default_parametrization(backend::ReactiveMPGraphPPLBackend, nodetype::GraphPPL.Atomic, factor::Type{Gamma}, rhs) = begin
     @warn "'Gamma' and 'GammaShapeScale' without keywords are constructed with parameters (Shape, Scale)."
     return GraphPPL.default_parametrization(backend, nodetype, ReactiveMP.inputinterfaces(factor), factor, rhs) 
end`
This allows to define `GammaShapeScale(1,1) `as well as `Gamma(1,1)` both returning the warning as well as `Gamma{Float64}(α=1.0, θ=1.0)`

Also added tests for initialization macro (but also works for model macro). not sure whether we should add further tests there as well.
TO-DO: if this sounds cool, we need to update test nr. 9 of "convert_init_node_aliases" in my other PR:
`    # Test 9: Positional Gamma should warn and be treated as (shape, scale)
    input = quote
        μ(x) = Gamma(2.0, 1.0)
    end
    @test_logs (:warn, "'Gamma' and 'GammaShapeScale' without keywords are constructed with parameters (Shape, Scale).") apply_pipeline(input, convert_init_node_aliases)
`