### PR TITLE
Remove vibe coded fields from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -10,15 +10,6 @@ body:
         
         Features are high-level capabilities that belong to an Epic. Use this template to define a feature that will be broken down into specific tasks.
 
-  - type: input
-    id: epic-reference
-    attributes:
-      label: Parent Epic
-      description: Link to the Epic this feature belongs to (use #issue-number)
-      placeholder: "#123"
-    validations:
-      required: true
-
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -8,15 +8,6 @@ body:
       value: |
         Tasks are specific, actionable work items that belong to a Feature. Use this template to define a task that contributes to a feature's goals.
 
-  - type: input
-    id: feature-reference
-    attributes:
-      label: Parent Feature
-      description: Link to the Feature this task belongs to (use #issue-number)
-      placeholder: "#123"
-    validations:
-      required: true
-
   - type: textarea
     id: summary
     attributes:
@@ -66,18 +57,6 @@ body:
         - Depends on task #456
         - Blocks task #789
 
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      description: What is the priority of this task?
-      options:
-        - "Low"
-        - "Medium"
-        - "High"
-        - "Critical"
-    validations:
-      required: true
 
   - type: textarea
     id: estimated-effort


### PR DESCRIPTION
Stuff like `Priority` and parent issue were purely text based and did not link to github functionality so they were just purely vibe coded nonsense. This PR removes them