### PR TITLE
feat: add TensorBoardLoggerExt for exporting inference traces to TensorBoard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `TensorBoardLoggerExt`: fixed `FieldError` thrown by `TensorBoardLogger 0.1.26` when reading back event logs. The package's `deserialize_tensor_summary` still accesses `summary.tensor` but the regenerated protobuf stubs store the tensor inside `summary.value.value` (`OneOf`). Test helpers now bypass the broken deserializer by iterating event files directly via `TBEventFileCollectionIterator` and reading `summary.tag` / `event.step` without deserialising tensor payloads.
-- `TensorBoardLoggerExt`: fixed `IOError: EBUSY` on Windows during test cleanup. `TBLogger` keeps the `.tfevents` file handle open after `close()`; `mktempdir`'s automatic `rm` raced against the OS releasing the handle and emitted an `@error` that VS Code's test runner surfaced as a red failure. The extension now calls `empty!(logger.all_files)` and `GC.gc()` after closing, and tests use a retry-cleanup helper (`with_safe_tempdir`) instead of plain `mktempdir`.
-- `TensorBoardLoggerExt`: fixed log output being silently redirected to a `_1`-suffixed sibling directory. `TBLogger` defaults to `tb_increment` mode, which renames the target when it already exists (including directories created by `mktempdir`). Changed to `tb_append` so logs always land in the directory passed by the caller.
+- Added `TensorBoardLoggerExt` extension: when `TensorBoardLogger.jl` is loaded, `RxInfer.convert_to_tensorboard(trace)` exports an inference trace to TensorBoard event log files. Capabilities:
+  - **Iteration timing** — wall-clock duration of each variational iteration logged as `iteration_time_ms`.
+  - **Posterior scalars** — per-iteration mean/precision for `Normal` and shape/rate for `Gamma` marginals under `posteriors/<variable>/`.
+  - **Posterior distributions** — per-iteration `HistogramSummary` (ridgeline + percentile bands in TensorBoard) via `log_distributions = true` and configurable `n_samples`.
+  - **Event text breadcrumbs** — full per-event narrative (`Events`, `before_iteration`, `after_iteration`, etc.) gated behind `log_text_events = true` (off by default). `EventCounts` is always emitted as a compact run summary.
+  - Logs are written to `tensorboard_logs/` in the current working directory by default; a custom path can be supplied via `output_file`.
+
 
 ## [5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - Added `TensorBoardLoggerExt` extension: when `TensorBoardLogger.jl` is loaded, `RxInfer.convert_to_tensorboard(trace)` exports an inference trace to TensorBoard event log files. Capabilities:
   - **Iteration timing** — wall-clock duration of each variational iteration logged as `iteration_time_ms`.
   - **Posterior scalars** — per-iteration mean/precision for `Normal` and shape/rate for `Gamma` marginals under `posteriors/<variable>/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Fixed
 - Added `TensorBoardLoggerExt` extension: when `TensorBoardLogger.jl` is loaded, `RxInfer.convert_to_tensorboard(trace)` exports an inference trace to TensorBoard event log files. Capabilities:
   - **Iteration timing** — wall-clock duration of each variational iteration logged as `iteration_time_ms`.
   - **Posterior scalars** — per-iteration mean/precision for `Normal` and shape/rate for `Gamma` marginals under `posteriors/<variable>/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `TensorBoardLoggerExt`: fixed `FieldError` thrown by `TensorBoardLogger 0.1.26` when reading back event logs. The package's `deserialize_tensor_summary` still accesses `summary.tensor` but the regenerated protobuf stubs store the tensor inside `summary.value.value` (`OneOf`). Test helpers now bypass the broken deserializer by iterating event files directly via `TBEventFileCollectionIterator` and reading `summary.tag` / `event.step` without deserialising tensor payloads.
+- `TensorBoardLoggerExt`: fixed `IOError: EBUSY` on Windows during test cleanup. `TBLogger` keeps the `.tfevents` file handle open after `close()`; `mktempdir`'s automatic `rm` raced against the OS releasing the handle and emitted an `@error` that VS Code's test runner surfaced as a red failure. The extension now calls `empty!(logger.all_files)` and `GC.gc()` after closing, and tests use a retry-cleanup helper (`with_safe_tempdir`) instead of plain `mktempdir`.
+- `TensorBoardLoggerExt`: fixed log output being silently redirected to a `_1`-suffixed sibling directory. `TBLogger` defaults to `tb_increment` mode, which renames the target when it already exists (including directories created by `mktempdir`). Changed to `tb_append` so logs always land in the directory passed by the caller.
+
 ## [5.0.0]
 
 - **Breaking:** Addons have been renamed to annotations to match the new ReactiveMP API. This affects the `infer` function and related types:

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -175,12 +175,6 @@ log_dir = RxInfer.convert_to_tensorboard(trace; log_distributions = true)
 | `log_text_events` | `false` | Emit per-event text breadcrumbs to the Text tab |
 | `n_samples` | `1024` | Samples drawn per posterior to build each histogram |
 
-### API Reference
-
-```@docs
-RxInfer.convert_to_tensorboard
-```
-
 ## API Reference
 
 ```@docs

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -166,14 +166,9 @@ log_dir = RxInfer.convert_to_tensorboard(trace; log_distributions = true)
 | Per-iteration histogram of posterior samples | Distributions / Histograms | `log_distributions = true` |
 | Event breadcrumbs and `EventCounts` table | Text | `log_text_events = true` (counts always written) |
 
-### Options
-
-| Keyword | Default | Description |
-|---------|---------|-------------|
-| `output_file` | `"tensorboard_logs/"` in `pwd()` | Directory to write event files into |
-| `log_distributions` | `false` | Log posterior histograms (one per iteration per variable) |
-| `log_text_events` | `false` | Emit per-event text breadcrumbs to the Text tab |
-| `n_samples` | `1024` | Samples drawn per posterior to build each histogram |
+```@docs 
+RxInfer.convert_to_tensorboard
+```
 
 ## API Reference
 

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -133,6 +133,54 @@ println("Trace included: ", haskey(result.model.metadata, :trace))
 println("Benchmark included: ", haskey(result.model.metadata, :benchmark))
 ```
 
+## Exporting to TensorBoard
+
+When [`TensorBoardLogger.jl`](https://github.com/PhilipVinc/TensorBoardLogger.jl) is loaded, the `TensorBoardLoggerExt` extension activates and provides `RxInfer.convert_to_tensorboard`, which converts a recorded trace into TensorFlow event files readable by TensorBoard.
+
+```julia
+using RxInfer
+using TensorBoardLogger  # activates the extension
+
+result = infer(
+    model = iid_normal(),
+    data = (y = randn(10),),
+    constraints = MeanField(),
+    iterations = 5,
+    initialization = init,
+    trace = true,
+)
+
+trace = result.model.metadata[:trace]
+
+log_dir = RxInfer.convert_to_tensorboard(trace; log_distributions = true)
+# Then run: tensorboard --logdir="<log_dir>"
+```
+
+### What gets logged
+
+| Output | TensorBoard tab | Condition |
+|--------|----------------|-----------|
+| Per-iteration wall-clock duration (`iteration_time_ms`) | Scalars | always |
+| `mean` / `precision` for each Normal posterior | Scalars | always |
+| `shape` / `rate` for each Gamma posterior | Scalars | always |
+| Per-iteration histogram of posterior samples | Distributions / Histograms | `log_distributions = true` |
+| Event breadcrumbs and `EventCounts` table | Text | `log_text_events = true` (counts always written) |
+
+### Options
+
+| Keyword | Default | Description |
+|---------|---------|-------------|
+| `output_file` | `"tensorboard_logs/"` in `pwd()` | Directory to write event files into |
+| `log_distributions` | `false` | Log posterior histograms (one per iteration per variable) |
+| `log_text_events` | `false` | Emit per-event text breadcrumbs to the Text tab |
+| `n_samples` | `1024` | Samples drawn per posterior to build each histogram |
+
+### API Reference
+
+```@docs
+RxInfer.convert_to_tensorboard
+```
+
 ## API Reference
 
 ```@docs

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -1,351 +1,490 @@
 
 module TensorBoardLoggerExt
-    using RxInfer
-    using ReactiveMP: event_name, getdata
-    using ExponentialFamily: UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-    using Distributions: shape, rate
-    using Random: MersenneTwister
-    using Statistics: mean, var
-    using TensorBoardLogger
+using RxInfer
+using ReactiveMP: event_name, getdata
+using ExponentialFamily:
+    UnivariateNormalDistributionsFamily, GammaDistributionsFamily
+using Distributions: shape, rate
+using Random: MersenneTwister
+using Statistics: mean, var
+using TensorBoardLogger
 
-    # ─── Log context ──────────────────────────────────────────────────────────
-    # State holder threaded through every `log_event` method so that per-event
-    # dispatch can read/mutate shared counters, iteration timings, and the
-    # TBLogger without any top-level `isa` branching in the main loop. Mirrors
-    # the `RxInferBenchmarkCallbacks` pattern in `src/callbacks/benchmark.jl`.
-    #
-    # `current_time_ns` is refreshed by the main loop before each dispatch so
-    # that timing-sensitive methods (BeforeIterationEvent / AfterIterationEvent)
-    # can read the TracedEvent timestamp without widening every `log_event`
-    # method's signature with an unused argument.
-    mutable struct LogContext{L}
-        logger::L
-        iteration_durations::Dict{Int, Float64}
-        before_times::Dict{Any, Tuple{Int, UInt64}}
-        counts::Dict{Symbol, Int}
-        posterior_step::Dict{Symbol, Int}
-        log_distributions::Bool
-        log_text_events::Bool
-        n_samples::Int
-        current_time_ns::UInt64
-    end
+# ─── Log context ──────────────────────────────────────────────────────────
+# State holder threaded through every `log_event` method so that per-event
+# dispatch can read/mutate shared counters, iteration timings, and the
+# TBLogger without any top-level `isa` branching in the main loop. Mirrors
+# the `RxInferBenchmarkCallbacks` pattern in `src/callbacks/benchmark.jl`.
+#
+# `current_time_ns` is refreshed by the main loop before each dispatch so
+# that timing-sensitive methods (BeforeIterationEvent / AfterIterationEvent)
+# can read the TracedEvent timestamp without widening every `log_event`
+# method's signature with an unused argument.
+mutable struct LogContext{L}
+    logger::L
+    iteration_durations::Dict{Int, Float64}
+    before_times::Dict{Any, Tuple{Int, UInt64}}
+    counts::Dict{Symbol, Int}
+    posterior_step::Dict{Symbol, Int}
+    log_distributions::Bool
+    log_text_events::Bool
+    n_samples::Int
+    current_time_ns::UInt64
+end
 
-    LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::Int) = LogContext(
-        logger,
-        Dict{Int, Float64}(),
-        Dict{Any, Tuple{Int, UInt64}}(),
-        Dict{Symbol, Int}(),
-        Dict{Symbol, Int}(),
-        log_distributions,
-        log_text_events,
-        n_samples,
-        zero(UInt64),
+LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::Int) = LogContext(
+    logger,
+    Dict{Int, Float64}(),
+    Dict{Any, Tuple{Int, UInt64}}(),
+    Dict{Symbol, Int}(),
+    Dict{Symbol, Int}(),
+    log_distributions,
+    log_text_events,
+    n_samples,
+    zero(UInt64),
+)
+
+# Central gate for all narrative/event text summaries. Scalar and
+# histogram logging stays unconditional — only the per-event text
+# breadcrumbs are opt-in via `log_text_events`.
+@inline _log_text!(ctx::LogContext, tag, msg; step) =
+    ctx.log_text_events &&
+    TensorBoardLogger.log_text(ctx.logger, tag, msg; step = step)
+
+# ─── Distribution-family dispatched helpers ──────────────────────────────
+# Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
+# reproducible across re-runs. The `::Any` fallback returns an empty vector
+# so non-univariate or unsupported marginals are silently skipped without
+# any branching at the call site.
+_posterior_samples(dist::UnivariateNormalDistributionsFamily, n::Int) = rand(MersenneTwister(1), dist, n)
+_posterior_samples(dist::GammaDistributionsFamily, n::Int)            = rand(MersenneTwister(1), dist, n)
+_posterior_samples(::Any, ::Int)                                      = Float64[]
+
+# Scalar-posterior logging, dispatched on the distribution family's natural
+# parameterisation. Mutates `ctx.posterior_step` so the per-variable step
+# counter stays aligned with the distribution-summary step.
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/mean", mean(dist); step = step
     )
-
-    # Central gate for all narrative/event text summaries. Scalar and
-    # histogram logging stays unconditional — only the per-event text
-    # breadcrumbs are opt-in via `log_text_events`.
-    @inline _log_text!(ctx::LogContext, tag, msg; step) =
-        ctx.log_text_events && TensorBoardLogger.log_text(ctx.logger, tag, msg; step=step)
-
-    # ─── Distribution-family dispatched helpers ──────────────────────────────
-    # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
-    # reproducible across re-runs. The `::Any` fallback returns an empty vector
-    # so non-univariate or unsupported marginals are silently skipped without
-    # any branching at the call site.
-    _posterior_samples(dist::UnivariateNormalDistributionsFamily, n::Int) = rand(MersenneTwister(1), dist, n)
-    _posterior_samples(dist::GammaDistributionsFamily,            n::Int) = rand(MersenneTwister(1), dist, n)
-    _posterior_samples(::Any,                                     ::Int)  = Float64[]
-
-    # Scalar-posterior logging, dispatched on the distribution family's natural
-    # parameterisation. Mutates `ctx.posterior_step` so the per-variable step
-    # counter stays aligned with the distribution-summary step.
-    function _log_posterior_scalars!(ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol)
-        step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/mean",      mean(dist);     step=step)
-        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/precision", inv(var(dist)); step=step)
-    end
-    function _log_posterior_scalars!(ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol)
-        step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/shape", shape(dist); step=step)
-        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/rate",  rate(dist);  step=step)
-    end
-    _log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing
-
-    # Per-iteration HistogramSummary. The data-only `log_histogram` overload
-    # lets TB auto-bin each iteration's samples so HistogramProto.min/max track
-    # the actual sample extremes — that is what makes the Distributions plugin
-    # narrow the percentile bands as the posterior sharpens.
-    function _log_posterior_distribution!(ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol)
-        samples = _posterior_samples(dist, ctx.n_samples)
-        isempty(samples) && return nothing
-        step = get(ctx.posterior_step, name, 0)
-        TensorBoardLogger.log_histogram(ctx.logger, "posteriors/$(name)/distribution", samples; step=step)
-    end
-    function _log_posterior_distribution!(ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol)
-        samples = _posterior_samples(dist, ctx.n_samples)
-        isempty(samples) && return nothing
-        step = get(ctx.posterior_step, name, 0)
-        TensorBoardLogger.log_histogram(ctx.logger, "posteriors/$(name)/distribution", samples; step=step)
-    end
-    _log_posterior_distribution!(::LogContext, ::Any, ::Symbol) = nothing
-
-    # ─── Per-event-type logging methods ───────────────────────────────────────
-
-    function log_event(ctx::LogContext, ev::BeforeModelCreationEvent, idx)
-        _log_text!(ctx, "before_model_creation",
-            "span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::AfterModelCreationEvent, idx)
-        _log_text!(ctx, "after_model_creation",
-            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::BeforeInferenceEvent, idx)
-        _log_text!(ctx, "before_inference",
-            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::AfterInferenceEvent, idx)
-        _log_text!(ctx, "after_inference",
-            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    # BeforeIterationEvent absorbs the start-of-iteration timing bookkeeping
-    # that previously lived in a pre-scan loop — we now stash the start time
-    # in-line as events stream by, via `ctx.current_time_ns`.
-    function log_event(ctx::LogContext, ev::BeforeIterationEvent, _idx)
-        _log_text!(ctx, "before_iteration",
-            "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)"; step=ev.iteration)
-        ctx.before_times[ev.span_id] = (ev.iteration, ctx.current_time_ns)
-    end
-
-    # AfterIterationEvent pairs with the matching BeforeIterationEvent via
-    # `span_id` to compute and log the iteration's wall-clock duration.
-    function log_event(ctx::LogContext, ev::AfterIterationEvent, _idx)
-        _log_text!(ctx, "after_iteration",
-            "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)"; step=ev.iteration)
-        if haskey(ctx.before_times, ev.span_id)
-            (iter, t0) = ctx.before_times[ev.span_id]
-            duration_ms = (ctx.current_time_ns - t0) / 1e6
-            ctx.iteration_durations[iter] = duration_ms
-            TensorBoardLogger.log_value(ctx.logger, "iteration_time_ms", duration_ms; step=iter)
-        end
-    end
-
-    function log_event(ctx::LogContext, ev::BeforeDataUpdateEvent, idx)
-        _log_text!(ctx, "before_data_update",
-            "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::AfterDataUpdateEvent, idx)
-        _log_text!(ctx, "after_data_update",
-            "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    # OnMarginalUpdateEvent carries text, scalar, and distribution logging for
-    # the updated marginal. Family-specific behaviour is delegated to the
-    # dispatched `_log_posterior_*` helpers above. Scalar and distribution
-    # paths use independent try blocks so a failure in one does not suppress
-    # the other — and failures surface via `@warn` so they are never silently
-    # swallowed (the previous `@debug` hid real errors from the user).
-    function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
-        _log_text!(ctx, "on_marginal_update/$(ev.variable_name)",
-            "model: $(ev.model) | variable: $(ev.variable_name) | update: $(ev.update)"; step=idx)
-        dist = try
-            getdata(ev.update)
-        catch err
-            @warn "Failed to unwrap marginal" variable_name=ev.variable_name exception=(err, catch_backtrace())
-            return nothing
-        end
-        try
-            _log_posterior_scalars!(ctx, dist, ev.variable_name)
-        catch err
-            @warn "Failed to log posterior scalars" variable_name=ev.variable_name exception=(err, catch_backtrace())
-        end
-        if ctx.log_distributions
-            try
-                _log_posterior_distribution!(ctx, dist, ev.variable_name)
-            catch err
-                @warn "Failed to log posterior distribution" variable_name=ev.variable_name exception=(err, catch_backtrace())
-            end
-        end
-    end
-
-    function log_event(ctx::LogContext, ev::BeforeAutostartEvent, idx)
-        _log_text!(ctx, "before_autostart",
-            "engine: $(ev.engine) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::AfterAutostartEvent, idx)
-        _log_text!(ctx, "after_autostart",
-            "engine: $(ev.engine) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx)
-        _log_text!(ctx, "before_message_rule_call",
-            "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.AfterMessageRuleCallEvent, idx)
-        _log_text!(ctx, "after_message_rule_call",
-            "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeProductOfMessagesEvent, idx)
-        _log_text!(ctx, "before_product_of_messages",
-            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.AfterProductOfMessagesEvent, idx)
-        _log_text!(ctx, "after_product_of_messages",
-            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeProductOfTwoMessagesEvent, idx)
-        _log_text!(ctx, "before_product_of_two_messages",
-            "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.AfterProductOfTwoMessagesEvent, idx)
-        _log_text!(ctx, "after_product_of_two_messages",
-            "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeMarginalComputationEvent, idx)
-        _log_text!(ctx, "before_marginal_computation",
-            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.AfterMarginalComputationEvent, idx)
-        _log_text!(ctx, "after_marginal_computation",
-            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeFormConstraintAppliedEvent, idx)
-        _log_text!(ctx, "before_form_constraint_applied",
-            "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    function log_event(ctx::LogContext, ev::ReactiveMP.AfterFormConstraintAppliedEvent, idx)
-        _log_text!(ctx, "after_form_constraint_applied",
-            "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
-    end
-
-    # Fallback for unknown event types
-    function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
-        _log_text!(ctx, "unknown_events",
-            "event_type: $(event_name(typeof(ev)))"; step=idx)
-    end
-
-    # ─── Main entry point ─────────────────────────────────────────────────────
-
-    """
-        convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
-                               log_distributions::Bool = false, log_text_events::Bool = false,
-                               n_samples::Int = 1024)
-
-    Convert trace events from inference to proper TensorFlow event files.
-
-    # Arguments
-    - `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
-    - `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, writes to `tensorboard_logs/` in the current working directory.
-    - `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
-    - `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
-    - `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
-
-    # Returns
-    - `String`: Path to the directory containing the TensorBoard event log files
-
-    # Description
-    This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
-    - Text summaries with event type information and counts
-    - Scalar time-series for univariate Normal (`mean`, `precision`) and Gamma (`shape`, `rate`) posteriors
-    - Scalar time-series for per-iteration wall-clock duration (`iteration_time_ms`)
-    - When `log_distributions=true`: per-iteration `HistogramSummary` under `posteriors/<var>/distribution`, rendered primarily in TensorBoard's Distributions tab
-
-    The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
-
-    # Example
-    ```julia
-    results = infer(
-        model = my_model(),
-        data = my_data,
-        trace = true
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/precision", inv(var(dist)); step = step
     )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
+    )
+end
+_log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing
 
-    trace = results.model.metadata[:trace]
+# Per-iteration HistogramSummary. The data-only `log_histogram` overload
+# lets TB auto-bin each iteration's samples so HistogramProto.min/max track
+# the actual sample extremes — that is what makes the Distributions plugin
+# narrow the percentile bands as the posterior sharpens.
+function _log_posterior_distribution!(
+    ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol
+)
+    samples = _posterior_samples(dist, ctx.n_samples)
+    isempty(samples) && return nothing
+    step = get(ctx.posterior_step, name, 0)
+    TensorBoardLogger.log_histogram(
+        ctx.logger, "posteriors/$(name)/distribution", samples; step = step
+    )
+end
+function _log_posterior_distribution!(
+    ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol
+)
+    samples = _posterior_samples(dist, ctx.n_samples)
+    isempty(samples) && return nothing
+    step = get(ctx.posterior_step, name, 0)
+    TensorBoardLogger.log_histogram(
+        ctx.logger, "posteriors/$(name)/distribution", samples; step = step
+    )
+end
+_log_posterior_distribution!(::LogContext, ::Any, ::Symbol) = nothing
 
-    # Create TensorBoard logs (writes to tensorboard_logs/ in the current directory)
-    log_dir = convert_to_tensorboard(trace; log_distributions = true)
+# ─── Per-event-type logging methods ───────────────────────────────────────
 
-    # Then run: tensorboard --logdir=\$log_dir
-    ```
-    """
-    function RxInfer.convert_to_tensorboard(trace::RxInferTraceCallbacks;
-                                            output_file::Union{String, Nothing} = nothing,
-                                            log_distributions::Bool = false,
-                                            log_text_events::Bool = false,
-                                            n_samples::Int = 1024)
+function log_event(ctx::LogContext, ev::BeforeModelCreationEvent, idx)
+    _log_text!(
+        ctx, "before_model_creation", "span_id: $(ev.span_id)"; step = idx
+    )
+end
 
-        if isnothing(output_file)
-            output_file = joinpath(pwd(), "tensorboard_logs")
-        end
+function log_event(ctx::LogContext, ev::AfterModelCreationEvent, idx)
+    _log_text!(
+        ctx,
+        "after_model_creation",
+        "model: $(ev.model) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
 
-        mkpath(output_file)
+function log_event(ctx::LogContext, ev::BeforeInferenceEvent, idx)
+    _log_text!(
+        ctx,
+        "before_inference",
+        "model: $(ev.model) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
 
-        events = RxInfer.tracedevents(trace)
+function log_event(ctx::LogContext, ev::AfterInferenceEvent, idx)
+    _log_text!(
+        ctx,
+        "after_inference",
+        "model: $(ev.model) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
 
-        if isempty(events)
-            @warn "No events recorded in trace"
-            return nothing
-        end
+# BeforeIterationEvent absorbs the start-of-iteration timing bookkeeping
+# that previously lived in a pre-scan loop — we now stash the start time
+# in-line as events stream by, via `ctx.current_time_ns`.
+function log_event(ctx::LogContext, ev::BeforeIterationEvent, _idx)
+    _log_text!(
+        ctx,
+        "before_iteration",
+        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
+        step = ev.iteration,
+    )
+    ctx.before_times[ev.span_id] = (ev.iteration, ctx.current_time_ns)
+end
 
-        @info "Collected $(length(events)) events from trace"
-
-        # `tb_append` keeps the logger writing into the exact directory the caller
-        # passed. The default `tb_increment` would see the pre-existing directory
-        # (we just `mkpath`'d it, and callers like `mktempdir` create it too) and
-        # silently redirect output to `${output_file}_1`, leaving the returned path
-        # empty.
-        logger = TBLogger(output_file, tb_append)
-        ctx    = LogContext(logger;
-                            log_distributions=log_distributions,
-                            log_text_events=log_text_events,
-                            n_samples=n_samples)
-
-        for (idx, traced) in enumerate(events)
-            ev     = traced.event
-            ev_sym = event_name(typeof(ev))
-            ctx.counts[ev_sym]   = get(ctx.counts, ev_sym, 0) + 1
-            ctx.current_time_ns  = traced.time_ns
-            _log_text!(ctx, "Events", "Step $idx: $(ev_sym)"; step=idx)
-            log_event(ctx, ev, idx)
-        end
-
-        sorted_counts = sort(collect(ctx.counts), by=first)
-        counts_table = reshape(
-            vcat(["$(k): $(v)" for (k, v) in sorted_counts], ["total: $(sum(values(ctx.counts)))"]),
-            :, 1
+# AfterIterationEvent pairs with the matching BeforeIterationEvent via
+# `span_id` to compute and log the iteration's wall-clock duration.
+function log_event(ctx::LogContext, ev::AfterIterationEvent, _idx)
+    _log_text!(
+        ctx,
+        "after_iteration",
+        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
+        step = ev.iteration,
+    )
+    if haskey(ctx.before_times, ev.span_id)
+        (iter, t0) = ctx.before_times[ev.span_id]
+        duration_ms = (ctx.current_time_ns - t0) / 1e6
+        ctx.iteration_durations[iter] = duration_ms
+        TensorBoardLogger.log_value(
+            ctx.logger, "iteration_time_ms", duration_ms; step = iter
         )
-        TensorBoardLogger.log_text(ctx.logger, "EventCounts", counts_table; step=1)
-
-        close(logger)
-        # Drop internal references to the closed IOStreams so any lingering
-        # Windows file-lock isn't held past this function's return. `mktempdir`
-        # cleanup in tests races `rm` against the OS releasing the handle, and
-        # emits an @error that VSCode's test-item runner surfaces as red.
-        empty!(logger.all_files)
-        GC.gc()
-
-        @info "TensorBoard logs exported to: $output_file"
-        @info "Total events logged: $(length(events))"
-        @info ""
-        @info "To view in TensorBoard, run:"
-        @info "  tensorboard --logdir=\"$output_file\""
-
-        return output_file
     end
+end
+
+function log_event(ctx::LogContext, ev::BeforeDataUpdateEvent, idx)
+    _log_text!(
+        ctx,
+        "before_data_update",
+        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(ctx::LogContext, ev::AfterDataUpdateEvent, idx)
+    _log_text!(
+        ctx,
+        "after_data_update",
+        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+# OnMarginalUpdateEvent carries text, scalar, and distribution logging for
+# the updated marginal. Family-specific behaviour is delegated to the
+# dispatched `_log_posterior_*` helpers above. Scalar and distribution
+# paths use independent try blocks so a failure in one does not suppress
+# the other — and failures surface via `@warn` so they are never silently
+# swallowed (the previous `@debug` hid real errors from the user).
+function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
+    _log_text!(
+        ctx,
+        "on_marginal_update/$(ev.variable_name)",
+        "model: $(ev.model) | variable: $(ev.variable_name) | update: $(ev.update)";
+        step = idx,
+    )
+    dist = try
+        getdata(ev.update)
+    catch err
+        @warn "Failed to unwrap marginal" variable_name=ev.variable_name exception=(
+            err, catch_backtrace()
+        )
+        return nothing
+    end
+    try
+        _log_posterior_scalars!(ctx, dist, ev.variable_name)
+    catch err
+        @warn "Failed to log posterior scalars" variable_name=ev.variable_name exception=(
+            err, catch_backtrace()
+        )
+    end
+    if ctx.log_distributions
+        try
+            _log_posterior_distribution!(ctx, dist, ev.variable_name)
+        catch err
+            @warn "Failed to log posterior distribution" variable_name=ev.variable_name exception=(
+                err, catch_backtrace()
+            )
+        end
+    end
+end
+
+function log_event(ctx::LogContext, ev::BeforeAutostartEvent, idx)
+    _log_text!(
+        ctx,
+        "before_autostart",
+        "engine: $(ev.engine) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(ctx::LogContext, ev::AfterAutostartEvent, idx)
+    _log_text!(
+        ctx,
+        "after_autostart",
+        "engine: $(ev.engine) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx
+)
+    _log_text!(
+        ctx,
+        "before_message_rule_call",
+        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.AfterMessageRuleCallEvent, idx
+)
+    _log_text!(
+        ctx,
+        "after_message_rule_call",
+        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.BeforeProductOfMessagesEvent, idx
+)
+    _log_text!(
+        ctx,
+        "before_product_of_messages",
+        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.AfterProductOfMessagesEvent, idx
+)
+    _log_text!(
+        ctx,
+        "after_product_of_messages",
+        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.BeforeProductOfTwoMessagesEvent, idx
+)
+    _log_text!(
+        ctx,
+        "before_product_of_two_messages",
+        "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.AfterProductOfTwoMessagesEvent, idx
+)
+    _log_text!(
+        ctx,
+        "after_product_of_two_messages",
+        "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.BeforeMarginalComputationEvent, idx
+)
+    _log_text!(
+        ctx,
+        "before_marginal_computation",
+        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.AfterMarginalComputationEvent, idx
+)
+    _log_text!(
+        ctx,
+        "after_marginal_computation",
+        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.BeforeFormConstraintAppliedEvent, idx
+)
+    _log_text!(
+        ctx,
+        "before_form_constraint_applied",
+        "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+function log_event(
+    ctx::LogContext, ev::ReactiveMP.AfterFormConstraintAppliedEvent, idx
+)
+    _log_text!(
+        ctx,
+        "after_form_constraint_applied",
+        "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | result: $(ev.result) | span_id: $(ev.span_id)";
+        step = idx,
+    )
+end
+
+# Fallback for unknown event types
+function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
+    _log_text!(
+        ctx,
+        "unknown_events",
+        "event_type: $(event_name(typeof(ev)))";
+        step = idx,
+    )
+end
+
+# ─── Main entry point ─────────────────────────────────────────────────────
+
+"""
+    convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
+                           log_distributions::Bool = false, log_text_events::Bool = false,
+                           n_samples::Int = 1024)
+
+Convert trace events from inference to proper TensorFlow event files.
+
+# Arguments
+- `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
+- `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, writes to `tensorboard_logs/` in the current working directory.
+- `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
+- `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
+- `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
+
+# Returns
+- `String`: Path to the directory containing the TensorBoard event log files
+
+# Description
+This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
+- Text summaries with event type information and counts
+- Scalar time-series for univariate Normal (`mean`, `precision`) and Gamma (`shape`, `rate`) posteriors
+- Scalar time-series for per-iteration wall-clock duration (`iteration_time_ms`)
+- When `log_distributions=true`: per-iteration `HistogramSummary` under `posteriors/<var>/distribution`, rendered primarily in TensorBoard's Distributions tab
+
+The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
+
+# Example
+```julia
+results = infer(
+    model = my_model(),
+    data = my_data,
+    trace = true
+)
+
+trace = results.model.metadata[:trace]
+
+# Create TensorBoard logs (writes to tensorboard_logs/ in the current directory)
+log_dir = convert_to_tensorboard(trace; log_distributions = true)
+
+# Then run: tensorboard --logdir=\$log_dir
+```
+"""
+function RxInfer.convert_to_tensorboard(
+    trace::RxInferTraceCallbacks;
+    output_file::Union{String, Nothing} = nothing,
+    log_distributions::Bool = false,
+    log_text_events::Bool = false,
+    n_samples::Int = 1024,
+)
+    if isnothing(output_file)
+        output_file = joinpath(pwd(), "tensorboard_logs")
+    end
+
+    mkpath(output_file)
+
+    events = RxInfer.tracedevents(trace)
+
+    if isempty(events)
+        @warn "No events recorded in trace"
+        return nothing
+    end
+
+    @info "Collected $(length(events)) events from trace"
+
+    # `tb_append` keeps the logger writing into the exact directory the caller
+    # passed. The default `tb_increment` would see the pre-existing directory
+    # (we just `mkpath`'d it, and callers like `mktempdir` create it too) and
+    # silently redirect output to `${output_file}_1`, leaving the returned path
+    # empty.
+    logger = TBLogger(output_file, tb_append)
+    ctx    = LogContext(logger; log_distributions = log_distributions, log_text_events = log_text_events, n_samples = n_samples)
+
+    for (idx, traced) in enumerate(events)
+        ev                  = traced.event
+        ev_sym              = event_name(typeof(ev))
+        ctx.counts[ev_sym]  = get(ctx.counts, ev_sym, 0) + 1
+        ctx.current_time_ns = traced.time_ns
+        _log_text!(ctx, "Events", "Step $idx: $(ev_sym)"; step = idx)
+        log_event(ctx, ev, idx)
+    end
+
+    sorted_counts = sort(collect(ctx.counts); by = first)
+    counts_table = reshape(
+        vcat(
+            ["$(k): $(v)" for (k, v) in sorted_counts],
+            ["total: $(sum(values(ctx.counts)))"],
+        ),
+        :,
+        1,
+    )
+    TensorBoardLogger.log_text(
+        ctx.logger, "EventCounts", counts_table; step = 1
+    )
+
+    close(logger)
+    # Drop internal references to the closed IOStreams so any lingering
+    # Windows file-lock isn't held past this function's return. `mktempdir`
+    # cleanup in tests races `rm` against the OS releasing the handle, and
+    # emits an @error that VSCode's test-item runner surfaces as red.
+    empty!(logger.all_files)
+    GC.gc()
+
+    @info "TensorBoard logs exported to: $output_file"
+    @info "Total events logged: $(length(events))"
+    @info ""
+    @info "To view in TensorBoard, run:"
+    @info "  tensorboard --logdir=\"$output_file\""
+
+    return output_file
+end
 
 end

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -371,6 +371,7 @@ function RxInfer.convert_to_tensorboard(
     log_distributions::Bool = false,
     log_text_events::Bool = false,
     n_samples::Int = 1024,
+    verbose = true,
 )
     if isnothing(output_file)
         output_file = joinpath(pwd(), "tensorboard_logs")
@@ -385,7 +386,9 @@ function RxInfer.convert_to_tensorboard(
         return nothing
     end
 
-    @info "Collected $(length(events)) events from trace"
+    if verbose
+        @info "Collected $(length(events)) events from trace"
+    end
 
     log_subdir = joinpath(output_file, format(now(), "yyyy-mm-dd_HH-MM-SS"))
     mkpath(log_subdir)
@@ -422,11 +425,13 @@ function RxInfer.convert_to_tensorboard(
     empty!(logger.all_files)
     GC.gc()
 
-    @info "TensorBoard logs exported to: $log_subdir"
-    @info "Total events logged: $(length(events))"
-    @info ""
-    @info "To view in TensorBoard, run:"
-    @info "  tensorboard --logdir=\"$output_file\""
+    if verbose
+        @info "TensorBoard logs exported to: $log_subdir"
+        @info "Total events logged: $(length(events))"
+        @info ""
+        @info "To view in TensorBoard, run:"
+        @info "  tensorboard --logdir=\"$output_file\""
+    end
 
     return log_subdir
 end

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -203,7 +203,7 @@ function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
     dist = try
         getdata(ev.update)
     catch err
-        @warn "Failed to unwrap marginal" variable_name=ev.variable_name exception=(
+        @warn "Failed to unwrap marginal" variable_name = ev.variable_name exception = (
             err, catch_backtrace()
         )
         return nothing
@@ -211,7 +211,7 @@ function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
     try
         _log_posterior_scalars!(ctx, dist, ev.variable_name)
     catch err
-        @warn "Failed to log posterior scalars" variable_name=ev.variable_name exception=(
+        @warn "Failed to log posterior scalars" variable_name = ev.variable_name exception = (
             err, catch_backtrace()
         )
     end
@@ -219,9 +219,8 @@ function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
         try
             _log_posterior_distribution!(ctx, dist, ev.variable_name)
         catch err
-            @warn "Failed to log posterior distribution" variable_name=ev.variable_name exception=(
-                err, catch_backtrace()
-            )
+            @warn "Failed to log posterior distribution" variable_name =
+                ev.variable_name exception = (err, catch_backtrace())
         end
     end
 end
@@ -364,50 +363,8 @@ function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
     )
 end
 
-# ─── Main entry point ─────────────────────────────────────────────────────
-
-"""
-    convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
-                           log_distributions::Bool = false, log_text_events::Bool = false,
-                           n_samples::Int = 1024)
-
-Convert trace events from inference to proper TensorFlow event files.
-
-# Arguments
-- `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
-- `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, writes to `tensorboard_logs/` in the current working directory.
-- `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
-- `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
-- `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
-
-# Returns
-- `String`: Path to the directory containing the TensorBoard event log files
-
-# Description
-This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
-- Text summaries with event type information and counts
-- Scalar time-series for univariate Normal (`mean`, `precision`) and Gamma (`shape`, `rate`) posteriors
-- Scalar time-series for per-iteration wall-clock duration (`iteration_time_ms`)
-- When `log_distributions=true`: per-iteration `HistogramSummary` under `posteriors/<var>/distribution`, rendered primarily in TensorBoard's Distributions tab
-
-The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
-
-# Example
-```julia
-results = infer(
-    model = my_model(),
-    data = my_data,
-    trace = true
-)
-
-trace = results.model.metadata[:trace]
-
-# Create TensorBoard logs (writes to tensorboard_logs/ in the current directory)
-log_dir = convert_to_tensorboard(trace; log_distributions = true)
-
-# Then run: tensorboard --logdir=\$log_dir
-```
-"""
+# defined in RxInfer.jl in src/callbacks/trace.jl
+# this module extends it
 function RxInfer.convert_to_tensorboard(
     trace::RxInferTraceCallbacks;
     output_file::Union{String, Nothing} = nothing,

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -1,330 +1,351 @@
+
 module TensorBoardLoggerExt
-using RxInfer
-using Dates
-using ReactiveMP: event_name
-using TensorBoardLogger
+    using RxInfer
+    using ReactiveMP: event_name, getdata
+    using ExponentialFamily: UnivariateNormalDistributionsFamily, GammaDistributionsFamily
+    using Distributions: shape, rate
+    using Random: MersenneTwister
+    using Statistics: mean, var
+    using TensorBoardLogger
 
-# ─── Per-event-type logging methods ───────────────────────────────────────
-
-function log_event(logger, ev::BeforeModelCreationEvent, idx)
-    TensorBoardLogger.log_text(
-        logger, "before_model_creation", "span_id: $(ev.span_id)"; step = idx
-    )
-end
-
-function log_event(logger, ev::AfterModelCreationEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_model_creation",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::BeforeInferenceEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_inference",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::AfterInferenceEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_inference",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::BeforeIterationEvent, _idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_iteration",
-        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
-        step = ev.iteration,
-    )
-end
-
-function log_event(logger, ev::AfterIterationEvent, _idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_iteration",
-        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
-        step = ev.iteration,
-    )
-end
-
-function log_event(logger, ev::BeforeDataUpdateEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_data_update",
-        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::AfterDataUpdateEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_data_update",
-        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::OnMarginalUpdateEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "on_marginal_update/$(ev.variable_name)",
-        "model: $(ev.model) | variable: $(ev.variable_name) | update: $(ev.update)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::BeforeAutostartEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_autostart",
-        "engine: $(ev.engine) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::AfterAutostartEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_autostart",
-        "engine: $(ev.engine) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_message_rule_call",
-        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.AfterMessageRuleCallEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_message_rule_call",
-        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.BeforeProductOfMessagesEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_product_of_messages",
-        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.AfterProductOfMessagesEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_product_of_messages",
-        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.BeforeProductOfTwoMessagesEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_product_of_two_messages",
-        "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.AfterProductOfTwoMessagesEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_product_of_two_messages",
-        "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.BeforeMarginalComputationEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_marginal_computation",
-        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.AfterMarginalComputationEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_marginal_computation",
-        "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.BeforeFormConstraintAppliedEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "before_form_constraint_applied",
-        "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-function log_event(logger, ev::ReactiveMP.AfterFormConstraintAppliedEvent, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "after_form_constraint_applied",
-        "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | result: $(ev.result) | span_id: $(ev.span_id)";
-        step = idx,
-    )
-end
-
-# Fallback for unknown event types
-function log_event(logger, ev::ReactiveMP.Event, idx)
-    TensorBoardLogger.log_text(
-        logger,
-        "unknown_events",
-        "event_type: $(event_name(typeof(ev)))";
-        step = idx,
-    )
-end
-
-# ─── Main entry point ─────────────────────────────────────────────────────
-
-"""
-    convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing)
-
-Convert trace events from inference to proper TensorFlow event files.
-
-# Arguments
-- `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
-- `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, uses a timestamped directory in the current working directory.
-
-# Returns
-- `String`: Path to the directory containing the TensorBoard event log files
-
-# Description
-This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
-- Text summaries with event type information and counts
-
-The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
-
-# Example
-```julia
-results = infer(
-    model = my_model(),
-    data = my_data,
-    trace = true
-)
-
-trace = results.model.metadata[:trace]
-
-# Create TensorBoard logs (uses timestamped directory)
-log_dir = convert_to_tensorboard(trace)
-
-# Then run: tensorboard --logdir=\$log_dir
-```
-"""
-function RxInfer.convert_to_tensorboard(
-    trace::RxInferTraceCallbacks;
-    output_file::Union{String, Nothing} = nothing,
-    verbose = true,
-)
-    if isnothing(output_file)
-        timestamp = Dates.format(Dates.now(), "yyyy-mm-dd_HH-MM-SS")
-        output_file = joinpath(pwd(), "tensorboard_logs", timestamp)
+    # ─── Log context ──────────────────────────────────────────────────────────
+    # State holder threaded through every `log_event` method so that per-event
+    # dispatch can read/mutate shared counters, iteration timings, and the
+    # TBLogger without any top-level `isa` branching in the main loop. Mirrors
+    # the `RxInferBenchmarkCallbacks` pattern in `src/callbacks/benchmark.jl`.
+    #
+    # `current_time_ns` is refreshed by the main loop before each dispatch so
+    # that timing-sensitive methods (BeforeIterationEvent / AfterIterationEvent)
+    # can read the TracedEvent timestamp without widening every `log_event`
+    # method's signature with an unused argument.
+    mutable struct LogContext{L}
+        logger::L
+        iteration_durations::Dict{Int, Float64}
+        before_times::Dict{Any, Tuple{Int, UInt64}}
+        counts::Dict{Symbol, Int}
+        posterior_step::Dict{Symbol, Int}
+        log_distributions::Bool
+        log_text_events::Bool
+        n_samples::Int
+        current_time_ns::UInt64
     end
 
-    mkpath(output_file)
+    LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::Int) = LogContext(
+        logger,
+        Dict{Int, Float64}(),
+        Dict{Any, Tuple{Int, UInt64}}(),
+        Dict{Symbol, Int}(),
+        Dict{Symbol, Int}(),
+        log_distributions,
+        log_text_events,
+        n_samples,
+        zero(UInt64),
+    )
 
-    events = RxInfer.tracedevents(trace)
+    # Central gate for all narrative/event text summaries. Scalar and
+    # histogram logging stays unconditional — only the per-event text
+    # breadcrumbs are opt-in via `log_text_events`.
+    @inline _log_text!(ctx::LogContext, tag, msg; step) =
+        ctx.log_text_events && TensorBoardLogger.log_text(ctx.logger, tag, msg; step=step)
 
-    if isempty(events)
-        @warn "No events recorded in trace"
-        return nothing
+    # ─── Distribution-family dispatched helpers ──────────────────────────────
+    # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
+    # reproducible across re-runs. The `::Any` fallback returns an empty vector
+    # so non-univariate or unsupported marginals are silently skipped without
+    # any branching at the call site.
+    _posterior_samples(dist::UnivariateNormalDistributionsFamily, n::Int) = rand(MersenneTwister(1), dist, n)
+    _posterior_samples(dist::GammaDistributionsFamily,            n::Int) = rand(MersenneTwister(1), dist, n)
+    _posterior_samples(::Any,                                     ::Int)  = Float64[]
+
+    # Scalar-posterior logging, dispatched on the distribution family's natural
+    # parameterisation. Mutates `ctx.posterior_step` so the per-variable step
+    # counter stays aligned with the distribution-summary step.
+    function _log_posterior_scalars!(ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol)
+        step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/mean",      mean(dist);     step=step)
+        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/precision", inv(var(dist)); step=step)
+    end
+    function _log_posterior_scalars!(ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol)
+        step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/shape", shape(dist); step=step)
+        TensorBoardLogger.log_value(ctx.logger, "posteriors/$(name)/rate",  rate(dist);  step=step)
+    end
+    _log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing
+
+    # Per-iteration HistogramSummary. The data-only `log_histogram` overload
+    # lets TB auto-bin each iteration's samples so HistogramProto.min/max track
+    # the actual sample extremes — that is what makes the Distributions plugin
+    # narrow the percentile bands as the posterior sharpens.
+    function _log_posterior_distribution!(ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol)
+        samples = _posterior_samples(dist, ctx.n_samples)
+        isempty(samples) && return nothing
+        step = get(ctx.posterior_step, name, 0)
+        TensorBoardLogger.log_histogram(ctx.logger, "posteriors/$(name)/distribution", samples; step=step)
+    end
+    function _log_posterior_distribution!(ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol)
+        samples = _posterior_samples(dist, ctx.n_samples)
+        isempty(samples) && return nothing
+        step = get(ctx.posterior_step, name, 0)
+        TensorBoardLogger.log_histogram(ctx.logger, "posteriors/$(name)/distribution", samples; step=step)
+    end
+    _log_posterior_distribution!(::LogContext, ::Any, ::Symbol) = nothing
+
+    # ─── Per-event-type logging methods ───────────────────────────────────────
+
+    function log_event(ctx::LogContext, ev::BeforeModelCreationEvent, idx)
+        _log_text!(ctx, "before_model_creation",
+            "span_id: $(ev.span_id)"; step=idx)
     end
 
-    if verbose
-        @info "Collected $(length(events)) events from trace"
+    function log_event(ctx::LogContext, ev::AfterModelCreationEvent, idx)
+        _log_text!(ctx, "after_model_creation",
+            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
     end
 
-    logger = TBLogger(output_file)
+    function log_event(ctx::LogContext, ev::BeforeInferenceEvent, idx)
+        _log_text!(ctx, "before_inference",
+            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
+    end
 
-    # Pre-compute iteration durations from matched before/after pairs via span_id
-    iteration_durations = Dict{Int, Float64}()
-    before_times = Dict{Any, Tuple{Int, UInt64}}()
-    for traced_event in events
-        ev = traced_event.event
-        et = event_name(typeof(ev))
-        if et === :before_iteration
-            before_times[ev.span_id] = (ev.iteration, traced_event.time_ns)
-        elseif et === :after_iteration
-            if haskey(before_times, ev.span_id)
-                (iter, t0) = before_times[ev.span_id]
-                iteration_durations[iter] = (traced_event.time_ns - t0) / 1e6
+    function log_event(ctx::LogContext, ev::AfterInferenceEvent, idx)
+        _log_text!(ctx, "after_inference",
+            "model: $(ev.model) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    # BeforeIterationEvent absorbs the start-of-iteration timing bookkeeping
+    # that previously lived in a pre-scan loop — we now stash the start time
+    # in-line as events stream by, via `ctx.current_time_ns`.
+    function log_event(ctx::LogContext, ev::BeforeIterationEvent, _idx)
+        _log_text!(ctx, "before_iteration",
+            "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)"; step=ev.iteration)
+        ctx.before_times[ev.span_id] = (ev.iteration, ctx.current_time_ns)
+    end
+
+    # AfterIterationEvent pairs with the matching BeforeIterationEvent via
+    # `span_id` to compute and log the iteration's wall-clock duration.
+    function log_event(ctx::LogContext, ev::AfterIterationEvent, _idx)
+        _log_text!(ctx, "after_iteration",
+            "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)"; step=ev.iteration)
+        if haskey(ctx.before_times, ev.span_id)
+            (iter, t0) = ctx.before_times[ev.span_id]
+            duration_ms = (ctx.current_time_ns - t0) / 1e6
+            ctx.iteration_durations[iter] = duration_ms
+            TensorBoardLogger.log_value(ctx.logger, "iteration_time_ms", duration_ms; step=iter)
+        end
+    end
+
+    function log_event(ctx::LogContext, ev::BeforeDataUpdateEvent, idx)
+        _log_text!(ctx, "before_data_update",
+            "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::AfterDataUpdateEvent, idx)
+        _log_text!(ctx, "after_data_update",
+            "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    # OnMarginalUpdateEvent carries text, scalar, and distribution logging for
+    # the updated marginal. Family-specific behaviour is delegated to the
+    # dispatched `_log_posterior_*` helpers above. Scalar and distribution
+    # paths use independent try blocks so a failure in one does not suppress
+    # the other — and failures surface via `@warn` so they are never silently
+    # swallowed (the previous `@debug` hid real errors from the user).
+    function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
+        _log_text!(ctx, "on_marginal_update/$(ev.variable_name)",
+            "model: $(ev.model) | variable: $(ev.variable_name) | update: $(ev.update)"; step=idx)
+        dist = try
+            getdata(ev.update)
+        catch err
+            @warn "Failed to unwrap marginal" variable_name=ev.variable_name exception=(err, catch_backtrace())
+            return nothing
+        end
+        try
+            _log_posterior_scalars!(ctx, dist, ev.variable_name)
+        catch err
+            @warn "Failed to log posterior scalars" variable_name=ev.variable_name exception=(err, catch_backtrace())
+        end
+        if ctx.log_distributions
+            try
+                _log_posterior_distribution!(ctx, dist, ev.variable_name)
+            catch err
+                @warn "Failed to log posterior distribution" variable_name=ev.variable_name exception=(err, catch_backtrace())
             end
         end
     end
 
-    counts = Dict{Symbol, Int}()
-
-    for (idx, traced_event) in enumerate(events)
-        ev = traced_event.event
-        event_type = event_name(typeof(ev))
-        counts[event_type] = get(counts, event_type, 0) + 1
-
-        TensorBoardLogger.log_text(
-            logger, "Events", "Step $idx: $(event_type)"; step = idx
-        )
-        log_event(logger, ev, idx)
-
-        # Log iteration wall-clock time as a scalar
-        if ev isa AfterIterationEvent &&
-            haskey(iteration_durations, ev.iteration)
-            TensorBoardLogger.log_value(
-                logger,
-                "iteration_time_ms",
-                iteration_durations[ev.iteration];
-                step = ev.iteration,
-            )
-        end
+    function log_event(ctx::LogContext, ev::BeforeAutostartEvent, idx)
+        _log_text!(ctx, "before_autostart",
+            "engine: $(ev.engine) | span_id: $(ev.span_id)"; step=idx)
     end
 
-    sorted_counts = sort(collect(counts); by = first)
-    counts_table = reshape(
-        vcat(
-            ["$(k): $(v)" for (k, v) in sorted_counts],
-            ["total: $(sum(values(counts)))"],
-        ),
-        :,
-        1,
+    function log_event(ctx::LogContext, ev::AfterAutostartEvent, idx)
+        _log_text!(ctx, "after_autostart",
+            "engine: $(ev.engine) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx)
+        _log_text!(ctx, "before_message_rule_call",
+            "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.AfterMessageRuleCallEvent, idx)
+        _log_text!(ctx, "after_message_rule_call",
+            "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeProductOfMessagesEvent, idx)
+        _log_text!(ctx, "before_product_of_messages",
+            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.AfterProductOfMessagesEvent, idx)
+        _log_text!(ctx, "after_product_of_messages",
+            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeProductOfTwoMessagesEvent, idx)
+        _log_text!(ctx, "before_product_of_two_messages",
+            "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.AfterProductOfTwoMessagesEvent, idx)
+        _log_text!(ctx, "after_product_of_two_messages",
+            "variable: $(ev.variable.label) | context: $(ev.context) | left: $(ev.left) | right: $(ev.right) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeMarginalComputationEvent, idx)
+        _log_text!(ctx, "before_marginal_computation",
+            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.AfterMarginalComputationEvent, idx)
+        _log_text!(ctx, "after_marginal_computation",
+            "variable: $(ev.variable.label) | context: $(ev.context) | messages: $(ev.messages) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.BeforeFormConstraintAppliedEvent, idx)
+        _log_text!(ctx, "before_form_constraint_applied",
+            "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    function log_event(ctx::LogContext, ev::ReactiveMP.AfterFormConstraintAppliedEvent, idx)
+        _log_text!(ctx, "after_form_constraint_applied",
+            "variable: $(ev.variable.label) | context: $(ev.context) | strategy: $(ev.strategy) | distribution: $(ev.distribution) | result: $(ev.result) | span_id: $(ev.span_id)"; step=idx)
+    end
+
+    # Fallback for unknown event types
+    function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
+        _log_text!(ctx, "unknown_events",
+            "event_type: $(event_name(typeof(ev)))"; step=idx)
+    end
+
+    # ─── Main entry point ─────────────────────────────────────────────────────
+
+    """
+        convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
+                               log_distributions::Bool = false, log_text_events::Bool = false,
+                               n_samples::Int = 1024)
+
+    Convert trace events from inference to proper TensorFlow event files.
+
+    # Arguments
+    - `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
+    - `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, writes to `tensorboard_logs/` in the current working directory.
+    - `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
+    - `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
+    - `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
+
+    # Returns
+    - `String`: Path to the directory containing the TensorBoard event log files
+
+    # Description
+    This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
+    - Text summaries with event type information and counts
+    - Scalar time-series for univariate Normal (`mean`, `precision`) and Gamma (`shape`, `rate`) posteriors
+    - Scalar time-series for per-iteration wall-clock duration (`iteration_time_ms`)
+    - When `log_distributions=true`: per-iteration `HistogramSummary` under `posteriors/<var>/distribution`, rendered primarily in TensorBoard's Distributions tab
+
+    The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
+
+    # Example
+    ```julia
+    results = infer(
+        model = my_model(),
+        data = my_data,
+        trace = true
     )
-    TensorBoardLogger.log_text(logger, "EventCounts", counts_table; step = 1)
 
-    close(logger)
+    trace = results.model.metadata[:trace]
 
-    if verbose
+    # Create TensorBoard logs (writes to tensorboard_logs/ in the current directory)
+    log_dir = convert_to_tensorboard(trace; log_distributions = true)
+
+    # Then run: tensorboard --logdir=\$log_dir
+    ```
+    """
+    function RxInfer.convert_to_tensorboard(trace::RxInferTraceCallbacks;
+                                            output_file::Union{String, Nothing} = nothing,
+                                            log_distributions::Bool = false,
+                                            log_text_events::Bool = false,
+                                            n_samples::Int = 1024)
+
+        if isnothing(output_file)
+            output_file = joinpath(pwd(), "tensorboard_logs")
+        end
+
+        mkpath(output_file)
+
+        events = RxInfer.tracedevents(trace)
+
+        if isempty(events)
+            @warn "No events recorded in trace"
+            return nothing
+        end
+
+        @info "Collected $(length(events)) events from trace"
+
+        # `tb_append` keeps the logger writing into the exact directory the caller
+        # passed. The default `tb_increment` would see the pre-existing directory
+        # (we just `mkpath`'d it, and callers like `mktempdir` create it too) and
+        # silently redirect output to `${output_file}_1`, leaving the returned path
+        # empty.
+        logger = TBLogger(output_file, tb_append)
+        ctx    = LogContext(logger;
+                            log_distributions=log_distributions,
+                            log_text_events=log_text_events,
+                            n_samples=n_samples)
+
+        for (idx, traced) in enumerate(events)
+            ev     = traced.event
+            ev_sym = event_name(typeof(ev))
+            ctx.counts[ev_sym]   = get(ctx.counts, ev_sym, 0) + 1
+            ctx.current_time_ns  = traced.time_ns
+            _log_text!(ctx, "Events", "Step $idx: $(ev_sym)"; step=idx)
+            log_event(ctx, ev, idx)
+        end
+
+        sorted_counts = sort(collect(ctx.counts), by=first)
+        counts_table = reshape(
+            vcat(["$(k): $(v)" for (k, v) in sorted_counts], ["total: $(sum(values(ctx.counts)))"]),
+            :, 1
+        )
+        TensorBoardLogger.log_text(ctx.logger, "EventCounts", counts_table; step=1)
+
+        close(logger)
+        # Drop internal references to the closed IOStreams so any lingering
+        # Windows file-lock isn't held past this function's return. `mktempdir`
+        # cleanup in tests races `rm` against the OS releasing the handle, and
+        # emits an @error that VSCode's test-item runner surfaces as red.
+        empty!(logger.all_files)
+        GC.gc()
+
         @info "TensorBoard logs exported to: $output_file"
         @info "Total events logged: $(length(events))"
         @info ""
         @info "To view in TensorBoard, run:"
         @info "  tensorboard --logdir=\"$output_file\""
-    end
 
-    return output_file
-end
+        return output_file
+    end
 
 end

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -5,6 +5,7 @@ using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
 using Distributions: UnivariateDistribution, shape, rate
+using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
 using TensorBoardLogger
@@ -429,12 +430,9 @@ function RxInfer.convert_to_tensorboard(
 
     @info "Collected $(length(events)) events from trace"
 
-    # `tb_append` keeps the logger writing into the exact directory the caller
-    # passed. The default `tb_increment` would see the pre-existing directory
-    # (we just `mkpath`'d it, and callers like `mktempdir` create it too) and
-    # silently redirect output to `${output_file}_1`, leaving the returned path
-    # empty.
-    logger = TBLogger(output_file, tb_append)
+    log_subdir = joinpath(output_file, format(now(), "yyyy-mm-dd_HH-MM-SS"))
+    mkpath(log_subdir)
+    logger = TBLogger(log_subdir, tb_append)
     ctx    = LogContext(logger; log_distributions = log_distributions, log_text_events = log_text_events, n_samples = n_samples)
 
     for (idx, traced) in enumerate(events)
@@ -467,13 +465,13 @@ function RxInfer.convert_to_tensorboard(
     empty!(logger.all_files)
     GC.gc()
 
-    @info "TensorBoard logs exported to: $output_file"
+    @info "TensorBoard logs exported to: $log_subdir"
     @info "Total events logged: $(length(events))"
     @info ""
     @info "To view in TensorBoard, run:"
     @info "  tensorboard --logdir=\"$output_file\""
 
-    return output_file
+    return log_subdir
 end
 
 end

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: shape, rate
+using Distributions: UnivariateDistribution, shape, rate
 using Random: MersenneTwister
 using Statistics: mean, var
 using TensorBoardLogger
@@ -55,9 +55,8 @@ LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::In
 # reproducible across re-runs. The `::Any` fallback returns an empty vector
 # so non-univariate or unsupported marginals are silently skipped without
 # any branching at the call site.
-_posterior_samples(dist::UnivariateNormalDistributionsFamily, n::Int) = rand(MersenneTwister(1), dist, n)
-_posterior_samples(dist::GammaDistributionsFamily, n::Int)            = rand(MersenneTwister(1), dist, n)
-_posterior_samples(::Any, ::Int)                                      = Float64[]
+_posterior_samples(dist::UnivariateDistribution, n::Int) = rand(MersenneTwister(1), dist, n)
+_posterior_samples(::Any, ::Int)                         = Float64[]
 
 # Scalar-posterior logging, dispatched on the distribution family's natural
 # parameterisation. Mutates `ctx.posterior_step` so the per-variable step
@@ -91,17 +90,7 @@ _log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing
 # the actual sample extremes — that is what makes the Distributions plugin
 # narrow the percentile bands as the posterior sharpens.
 function _log_posterior_distribution!(
-    ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol
-)
-    samples = _posterior_samples(dist, ctx.n_samples)
-    isempty(samples) && return nothing
-    step = get(ctx.posterior_step, name, 0)
-    TensorBoardLogger.log_histogram(
-        ctx.logger, "posteriors/$(name)/distribution", samples; step = step
-    )
-end
-function _log_posterior_distribution!(
-    ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol
+    ctx::LogContext, dist::UnivariateDistribution, name::Symbol
 )
     samples = _posterior_samples(dist, ctx.n_samples)
     isempty(samples) && return nothing

--- a/src/callbacks/trace.jl
+++ b/src/callbacks/trace.jl
@@ -139,4 +139,52 @@ function ReactiveMP.handle_event(
     return nothing
 end
 
-function convert_to_tensorboard end # This function is implemented in the external module `TensorBoardLoggerExt` to avoid adding a hard dependency on TensorBoardLogger.jl for users who don't need it.
+"""
+    convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
+                           log_distributions::Bool = false, log_text_events::Bool = false,
+                           n_samples::Int = 1024)
+
+Convert trace events from inference to proper TensorFlow event files. Note that this function will not work 
+unless `TensorBoardLogger.jl` is loaded in the present Julia session.
+
+# Arguments
+- `trace::RxInferTraceCallbacks`: The trace callbacks object from inference results
+- `output_file::Union{String, Nothing}`: Optional directory path to write TensorBoard event logs. If not provided, writes to `tensorboard_logs/` in the current working directory.
+- `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
+- `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
+- `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
+
+# Returns
+- `String`: Path to the directory containing the TensorBoard event log files
+
+# Description
+This function processes all traced events and creates proper TensorFlow event files using TensorBoardLogger, which can be directly imported and visualized in TensorBoard. Outputs include:
+- Text summaries with event type information and counts
+- Scalar time-series for univariate Normal (`mean`, `precision`) and Gamma (`shape`, `rate`) posteriors
+- Scalar time-series for per-iteration wall-clock duration (`iteration_time_ms`)
+- When `log_distributions=true`: per-iteration `HistogramSummary` under `posteriors/<var>/distribution`, rendered primarily in TensorBoard's Distributions tab
+
+The output directory can be directly opened in TensorBoard's web interface for visualization and analysis.
+
+# Example
+```julia
+results = infer(
+    model = my_model(),
+    data = my_data,
+    trace = true
+)
+
+trace = results.model.metadata[:trace]
+
+# Create TensorBoard logs (writes to tensorboard_logs/ in the current directory)
+log_dir = convert_to_tensorboard(trace; log_distributions = true)
+
+# Then run: tensorboard --logdir=\$log_dir
+```
+"""
+function convert_to_tensorboard(args...)
+    # This function is implemented in the external module `TensorBoardLoggerExt` to avoid adding a hard dependency on TensorBoardLogger.jl for users who don't need it.
+    error(
+        "`convert_to_tensorboard` method with the specified arguments were not found. Did you load the `TensorBoardLogger.jl` in the current session? Otherwise consult the documentation.",
+    )
+end

--- a/src/callbacks/trace.jl
+++ b/src/callbacks/trace.jl
@@ -142,7 +142,7 @@ end
 """
     convert_to_tensorboard(trace::RxInferTraceCallbacks; output_file::Union{String, Nothing} = nothing,
                            log_distributions::Bool = false, log_text_events::Bool = false,
-                           n_samples::Int = 1024)
+                           n_samples::Int = 1024, verbose::Bool = true)
 
 Convert trace events from inference to proper TensorFlow event files. Note that this function will not work 
 unless `TensorBoardLogger.jl` is loaded in the present Julia session.
@@ -153,6 +153,7 @@ unless `TensorBoardLogger.jl` is loaded in the present Julia session.
 - `log_distributions::Bool`: When `true`, log each univariate Normal and Gamma posterior as a per-iteration `HistogramSummary` so TensorBoard's **Distributions** tab renders a percentile-band view of the posterior across iterations. The same tag also appears in the **Histograms** tab as an offset ridgeline. Defaults to `false`.
 - `log_text_events::Bool`: When `true`, emit a per-event text breadcrumb (e.g. `before_iteration`, `after_marginal_computation`, and the `Events` step timeline) into the **Text** tab. The `EventCounts` summary is always written regardless of this flag. Scalar and histogram outputs are unaffected. Defaults to `false`.
 - `n_samples::Int`: Number of samples drawn from each posterior to build the per-iteration histogram when `log_distributions=true`. Defaults to 1024.
+- `verbose`: Whether to print useful information during export or not, defaults to `true`
 
 # Returns
 - `String`: Path to the directory containing the TensorBoard event log files

--- a/test/ext/TensorBoardLoggerExt/helpers.jl
+++ b/test/ext/TensorBoardLoggerExt/helpers.jl
@@ -13,14 +13,15 @@ using TensorBoardLogger: TensorBoardLogger
 # budget we leave the directory behind (the OS temp sweeper will reclaim
 # it) rather than failing the test.
 function with_safe_tempdir(fn)
-    log_dir = mktempdir(; cleanup=false)
+    log_dir = mktempdir(; cleanup = false)
     try
         fn(log_dir)
     finally
         for attempt in 1:40
             try
-                GC.gc(); GC.gc()
-                rm(log_dir; recursive=true, force=true)
+                GC.gc();
+                GC.gc()
+                rm(log_dir; recursive = true, force = true)
                 break
             catch
                 attempt == 40 || sleep(0.05)

--- a/test/ext/TensorBoardLoggerExt/helpers.jl
+++ b/test/ext/TensorBoardLoggerExt/helpers.jl
@@ -1,0 +1,71 @@
+using TensorBoardLogger: TensorBoardLogger
+
+# ─── Tempdir cleanup retry ────────────────────────────────────────────────
+# Windows file-handle release is asynchronous: TensorBoardLogger readers
+# and the ProtoBuf decoder keep the `.tfevents` file mapped for some time
+# after `close`. Julia's `mktempdir(fn)` tries to `rm` the directory in a
+# `finally` block and emits a loud `@error` when the unlink fails with
+# EBUSY — the VSCode test-item runner surfaces that error as a red failure
+# even though every `@test` passed.
+#
+# `with_safe_tempdir` runs with `cleanup=false`, then retries `rm` until
+# the OS releases the handle. If cleanup still fails after the retry
+# budget we leave the directory behind (the OS temp sweeper will reclaim
+# it) rather than failing the test.
+function with_safe_tempdir(fn)
+    log_dir = mktempdir(; cleanup=false)
+    try
+        fn(log_dir)
+    finally
+        for attempt in 1:40
+            try
+                GC.gc(); GC.gc()
+                rm(log_dir; recursive=true, force=true)
+                break
+            catch
+                attempt == 40 || sleep(0.05)
+            end
+        end
+    end
+end
+
+# ─── Event-file bypass readers ────────────────────────────────────────────
+# TensorBoardLogger 0.1.26's `deserialize_tensor_summary` (used internally
+# by `tags()` and `map_summaries()`) still reads `summary.tensor` — a
+# field that no longer exists on the regenerated `Summary.Value`, where
+# the tensor now lives at `summary.value.value` inside a `OneOf`. Any
+# logdir containing a text summary (we always write `EventCounts`) throws
+# `FieldError` when iterated through that path.
+#
+# The tests only need tag *names* and *step* numbers, not decoded tensor
+# payloads. These helpers iterate event files directly and access the
+# plain `summary.tag` / `event.step` fields, skipping the broken
+# deserializer entirely.
+function _each_summary(fn, logdir)
+    for event_file in TensorBoardLogger.TBEventFileCollectionIterator(logdir)
+        for event in event_file
+            event.what === nothing && continue
+            s = event.what.value
+            isa(s, TensorBoardLogger.Summary) || continue
+            for summary_value in s.value
+                fn(event.step, summary_value.tag)
+            end
+        end
+    end
+end
+
+function read_tags(logdir)
+    tags = Set{String}()
+    _each_summary(logdir) do _, tag
+        push!(tags, tag)
+    end
+    return tags
+end
+
+function steps_for_tag(logdir, tag)
+    steps = BitSet()
+    _each_summary(logdir) do step, t
+        t == tag && push!(steps, step)
+    end
+    return steps
+end

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -1,12 +1,13 @@
 @testitem "IID estimation trace to TensorBoard" begin
-    using RxInfer, StableRNGs, TensorBoardLogger, Logging
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
 
     # A simple IID model: observations are drawn from a Normal with unknown mean and precision.
     # Mean-field constraints decouple q(μ) and q(τ) for variational inference.
     @model function iid_estimation(y)
-        μ ~ Normal(; mean = 0.0, precision = 0.1)
-        τ ~ Gamma(; shape = 1.0, rate = 1.0)
-        y .~ Normal(; mean = μ, precision = τ)
+        μ  ~ Normal(mean = 0.0, precision = 0.1)
+        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        y .~ Normal(mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -19,13 +20,13 @@
     end
 
     # Generate synthetic observations from a known distribution so the test is reproducible.
-    hidden_μ = 3.1415
-    hidden_τ = 2.7182
-    dataset = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
+    hidden_μ       = 3.1415
+    hidden_τ       = 2.7182
+    dataset        = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
 
     # Run inference with `trace = true` so all internal events are recorded.
     # The trace is stored in the model metadata under the `:trace` key.
-    results = infer(;
+    results = infer(
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -36,40 +37,231 @@
 
     trace = results.model.metadata[:trace]
 
-    logger_io = IOBuffer()
-
     # Export the trace to TensorBoard format and verify the output.
-    # `mktempdir` ensures the log files are written to a temporary directory
-    # that is cleaned up automatically after the test, avoiding filesystem pollution.
-    mktempdir() do log_dir
-        Logging.with_logger(Logging.SimpleLogger(logger_io)) do
-            output = RxInfer.convert_to_tensorboard(
-                trace; output_file = log_dir, verbose = true
-            )
-            @test output == log_dir  # function returns the path it wrote to
-            @test isdir(log_dir)     # directory was created
-        end
+    # `with_safe_tempdir` keeps the log files in a temp directory that gets
+    # retry-cleaned after the test — avoiding Windows EBUSY on `.tfevents`
+    # handles that TB readers leave mapped past `close`.
+    with_safe_tempdir() do log_dir
+        output = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        @test output == log_dir  # function returns the path it wrote to
+        @test isdir(log_dir)     # directory was created
+    end
+end
 
-        collected_logs_verbose = String(take!(logger_io))
+@testitem "Posterior mean/precision scalars logged to TensorBoard" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
 
-        @test occursin("Collected", collected_logs_verbose)
-        @test occursin("events from trace", collected_logs_verbose)
-        @test occursin("To view in TensorBoard, run:", collected_logs_verbose)
+    # Same IID model — μ is univariate Normal, τ is Gamma.
+    # Both variables appear under `posteriors/*`, tagged with parameterization-specific names:
+    # Normal → mean/precision, Gamma → shape/rate.
+    @model function iid_estimation(y)
+        μ  ~ Normal(mean = 0.0, precision = 0.1)
+        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        y .~ Normal(mean = μ, precision = τ)
+    end
 
-        Logging.with_logger(Logging.SimpleLogger(logger_io)) do
-            output = RxInfer.convert_to_tensorboard(
-                trace; output_file = log_dir, verbose = false
-            )
-            @test output == log_dir  # function returns the path it wrote to
-            @test isdir(log_dir)     # directory was created
-        end
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
 
-        collected_logs_notverbose = String(take!(logger_io))
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
 
-        @test !occursin("Collected", collected_logs_notverbose)
-        @test !occursin("events from trace", collected_logs_notverbose)
-        @test !occursin(
-            "To view in TensorBoard, run:", collected_logs_notverbose
-        )
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
+
+    n_iterations = 5
+    results = infer(
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+
+        all_tags = read_tags(log_dir)
+
+        # μ is univariate Normal → should produce mean and precision scalar tags
+        @test "posteriors/μ/mean" in all_tags
+        @test "posteriors/μ/precision" in all_tags
+
+        # τ is Gamma → should produce shape and rate scalar tags
+        @test "posteriors/τ/shape" in all_tags
+        @test "posteriors/τ/rate" in all_tags
+
+        # Verify we emitted one step per iteration for μ's mean and τ's shape.
+        @test length(steps_for_tag(log_dir, "posteriors/μ/mean"))  == n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/τ/shape")) == n_iterations
+    end
+end
+
+@testitem "Posterior distributions logged as HistogramSummary" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Same IID model — μ is univariate Normal, τ is Gamma. With `log_distributions=true`
+    # both posteriors should produce a per-iteration HistogramSummary under
+    # `posteriors/<var>/distribution`, which TensorBoard renders in both the
+    # Distributions (percentile-band) and Histograms (ridgeline) dashboards.
+    @model function iid_estimation(y)
+        μ  ~ Normal(mean = 0.0, precision = 0.1)
+        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        y .~ Normal(mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
+
+    n_iterations = 4
+    results = infer(
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        RxInfer.convert_to_tensorboard(trace; output_file = log_dir,
+                                              log_distributions = true,
+                                              n_samples = 512)
+
+        all_tags = read_tags(log_dir)
+
+        # Distribution tags should exist for both the Normal and Gamma posteriors.
+        @test "posteriors/μ/distribution" in all_tags
+        @test "posteriors/τ/distribution" in all_tags
+
+        # One HistogramSummary per iteration for each variable.
+        @test length(steps_for_tag(log_dir, "posteriors/μ/distribution")) == n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/τ/distribution")) == n_iterations
+
+        # Scalar tags must still be present — distributions complement, not replace, scalars.
+        @test "posteriors/μ/mean" in all_tags
+        @test "posteriors/τ/shape" in all_tags
+    end
+end
+
+@testitem "Default trace export does not emit distribution tags" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Guard-rail: with the default `log_distributions=false`, the new code path must be
+    # inert — no `posteriors/*/distribution` tags should appear in the log.
+    @model function iid_estimation(y)
+        μ  ~ Normal(mean = 0.0, precision = 0.1)
+        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        y .~ Normal(mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 10)
+
+    results = infer(
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = 2,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        all_tags = read_tags(log_dir)
+        @test !("posteriors/μ/distribution" in all_tags)
+        @test !("posteriors/τ/distribution" in all_tags)
+    end
+end
+
+@testitem "Event text logging is opt-in via log_text_events" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # `log_text_events` gates every per-event text breadcrumb. With the default
+    # `false`, none of the narrative tags (`Events`, `before_iteration`, …,
+    # `EventCounts`) should appear. Flipping it to `true` must reinstate them
+    # without disturbing scalar outputs (`iteration_time_ms`, `posteriors/*/*`).
+    @model function iid_estimation(y)
+        μ  ~ Normal(mean = 0.0, precision = 0.1)
+        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        y .~ Normal(mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 10)
+
+    results = infer(
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = 2,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    # Default: per-event text breadcrumbs are suppressed; scalars still flow.
+    # `EventCounts` is always emitted as a compact run summary, regardless of the flag.
+    with_safe_tempdir() do log_dir
+        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        all_tags = read_tags(log_dir)
+        @test !("Events" in all_tags)
+        @test !("before_iteration" in all_tags)
+        @test !("after_iteration" in all_tags)
+        @test "EventCounts" in all_tags
+        @test "iteration_time_ms" in all_tags
+        @test "posteriors/μ/mean" in all_tags
+    end
+
+    # Opt-in: the full narrative layer comes back.
+    with_safe_tempdir() do log_dir
+        RxInfer.convert_to_tensorboard(trace; output_file = log_dir, log_text_events = true)
+        all_tags = read_tags(log_dir)
+        @test "Events" in all_tags
+        @test "EventCounts" in all_tags
+        @test "before_iteration" in all_tags
+        @test "after_iteration" in all_tags
+        # Scalars continue to coexist with the text tags.
+        @test "iteration_time_ms" in all_tags
+        @test "posteriors/μ/mean" in all_tags
     end
 end

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -85,9 +85,9 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
 
-        all_tags = read_tags(log_dir)
+        all_tags = read_tags(run_dir)
 
         # μ is univariate Normal → should produce mean and precision scalar tags
         @test "posteriors/μ/mean" in all_tags
@@ -98,9 +98,9 @@ end
         @test "posteriors/τ/rate" in all_tags
 
         # Verify we emitted one step per iteration for μ's mean and τ's shape.
-        @test length(steps_for_tag(log_dir, "posteriors/μ/mean")) ==
+        @test length(steps_for_tag(run_dir, "posteriors/μ/mean")) ==
             n_iterations
-        @test length(steps_for_tag(log_dir, "posteriors/τ/shape")) ==
+        @test length(steps_for_tag(run_dir, "posteriors/τ/shape")) ==
             n_iterations
     end
 end
@@ -143,23 +143,23 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(
+        run_dir = RxInfer.convert_to_tensorboard(
             trace;
             output_file = log_dir,
             log_distributions = true,
             n_samples = 512,
         )
 
-        all_tags = read_tags(log_dir)
+        all_tags = read_tags(run_dir)
 
         # Distribution tags should exist for both the Normal and Gamma posteriors.
         @test "posteriors/μ/distribution" in all_tags
         @test "posteriors/τ/distribution" in all_tags
 
         # One HistogramSummary per iteration for each variable.
-        @test length(steps_for_tag(log_dir, "posteriors/μ/distribution")) ==
+        @test length(steps_for_tag(run_dir, "posteriors/μ/distribution")) ==
             n_iterations
-        @test length(steps_for_tag(log_dir, "posteriors/τ/distribution")) ==
+        @test length(steps_for_tag(run_dir, "posteriors/τ/distribution")) ==
             n_iterations
 
         # Scalar tags must still be present — distributions complement, not replace, scalars.
@@ -203,8 +203,8 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
-        all_tags = read_tags(log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        all_tags = read_tags(run_dir)
         @test !("posteriors/μ/distribution" in all_tags)
         @test !("posteriors/τ/distribution" in all_tags)
     end
@@ -249,8 +249,8 @@ end
     # Default: per-event text breadcrumbs are suppressed; scalars still flow.
     # `EventCounts` is always emitted as a compact run summary, regardless of the flag.
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
-        all_tags = read_tags(log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        all_tags = read_tags(run_dir)
         @test !("Events" in all_tags)
         @test !("before_iteration" in all_tags)
         @test !("after_iteration" in all_tags)
@@ -261,10 +261,10 @@ end
 
     # Opt-in: the full narrative layer comes back.
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(
+        run_dir = RxInfer.convert_to_tensorboard(
             trace; output_file = log_dir, log_text_events = true
         )
-        all_tags = read_tags(log_dir)
+        all_tags = read_tags(run_dir)
         @test "Events" in all_tags
         @test "EventCounts" in all_tags
         @test "before_iteration" in all_tags

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -5,9 +5,9 @@
     # A simple IID model: observations are drawn from a Normal with unknown mean and precision.
     # Mean-field constraints decouple q(μ) and q(τ) for variational inference.
     @model function iid_estimation(y)
-        μ ~ Normal(mean = 0.0, precision = 0.1)
-        τ ~ Gamma(shape = 1.0, rate = 1.0)
-        y .~ Normal(mean = μ, precision = τ)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -22,11 +22,11 @@
     # Generate synthetic observations from a known distribution so the test is reproducible.
     hidden_μ = 3.1415
     hidden_τ = 2.7182
-    dataset   = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
+    dataset = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
 
     # Run inference with `trace = true` so all internal events are recorded.
     # The trace is stored in the model metadata under the `:trace` key.
-    results = infer(
+    results = infer(;
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -42,7 +42,9 @@
     # retry-cleaned after the test — avoiding Windows EBUSY on `.tfevents`
     # handles that TB readers leave mapped past `close`.
     with_safe_tempdir() do log_dir
-        output = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        output = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
         @test startswith(output, log_dir)  # returned path is a subdirectory of log_dir
         @test isdir(output)                # timestamped subdirectory was created
     end
@@ -56,9 +58,9 @@ end
     # Both variables appear under `posteriors/*`, tagged with parameterization-specific names:
     # Normal → mean/precision, Gamma → shape/rate.
     @model function iid_estimation(y)
-        μ ~ Normal(mean = 0.0, precision = 0.1)
-        τ ~ Gamma(shape = 1.0, rate = 1.0)
-        y .~ Normal(mean = μ, precision = τ)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -73,7 +75,7 @@ end
     dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
 
     n_iterations = 5
-    results = infer(
+    results = infer(;
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -85,7 +87,9 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
 
         all_tags = read_tags(run_dir)
 
@@ -114,9 +118,9 @@ end
     # `posteriors/<var>/distribution`, which TensorBoard renders in both the
     # Distributions (percentile-band) and Histograms (ridgeline) dashboards.
     @model function iid_estimation(y)
-        μ ~ Normal(mean = 0.0, precision = 0.1)
-        τ ~ Gamma(shape = 1.0, rate = 1.0)
-        y .~ Normal(mean = μ, precision = τ)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -131,7 +135,7 @@ end
     dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
 
     n_iterations = 4
-    results = infer(
+    results = infer(;
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -148,6 +152,7 @@ end
             output_file = log_dir,
             log_distributions = true,
             n_samples = 512,
+            verbose = false,
         )
 
         all_tags = read_tags(run_dir)
@@ -175,9 +180,9 @@ end
     # Guard-rail: with the default `log_distributions=false`, the new code path must be
     # inert — no `posteriors/*/distribution` tags should appear in the log.
     @model function iid_estimation(y)
-        μ ~ Normal(mean = 0.0, precision = 0.1)
-        τ ~ Gamma(shape = 1.0, rate = 1.0)
-        y .~ Normal(mean = μ, precision = τ)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -191,7 +196,7 @@ end
 
     dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 10)
 
-    results = infer(
+    results = infer(;
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -203,7 +208,9 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
         all_tags = read_tags(run_dir)
         @test !("posteriors/μ/distribution" in all_tags)
         @test !("posteriors/τ/distribution" in all_tags)
@@ -219,9 +226,9 @@ end
     # `EventCounts`) should appear. Flipping it to `true` must reinstate them
     # without disturbing scalar outputs (`iteration_time_ms`, `posteriors/*/*`).
     @model function iid_estimation(y)
-        μ ~ Normal(mean = 0.0, precision = 0.1)
-        τ ~ Gamma(shape = 1.0, rate = 1.0)
-        y .~ Normal(mean = μ, precision = τ)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
     end
 
     constraints = @constraints begin
@@ -235,7 +242,7 @@ end
 
     dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 10)
 
-    results = infer(
+    results = infer(;
         model          = iid_estimation(),
         data           = (y = dataset,),
         constraints    = constraints,
@@ -249,7 +256,9 @@ end
     # Default: per-event text breadcrumbs are suppressed; scalars still flow.
     # `EventCounts` is always emitted as a compact run summary, regardless of the flag.
     with_safe_tempdir() do log_dir
-        run_dir = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
         all_tags = read_tags(run_dir)
         @test !("Events" in all_tags)
         @test !("before_iteration" in all_tags)
@@ -262,7 +271,10 @@ end
     # Opt-in: the full narrative layer comes back.
     with_safe_tempdir() do log_dir
         run_dir = RxInfer.convert_to_tensorboard(
-            trace; output_file = log_dir, log_text_events = true
+            trace;
+            output_file = log_dir,
+            log_text_events = true,
+            verbose = false,
         )
         all_tags = read_tags(run_dir)
         @test "Events" in all_tags

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -43,8 +43,8 @@
     # handles that TB readers leave mapped past `close`.
     with_safe_tempdir() do log_dir
         output = RxInfer.convert_to_tensorboard(trace; output_file = log_dir)
-        @test output == log_dir  # function returns the path it wrote to
-        @test isdir(log_dir)     # directory was created
+        @test startswith(output, log_dir)  # returned path is a subdirectory of log_dir
+        @test isdir(output)                # timestamped subdirectory was created
     end
 end
 

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -5,8 +5,8 @@
     # A simple IID model: observations are drawn from a Normal with unknown mean and precision.
     # Mean-field constraints decouple q(μ) and q(τ) for variational inference.
     @model function iid_estimation(y)
-        μ  ~ Normal(mean = 0.0, precision = 0.1)
-        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        μ ~ Normal(mean = 0.0, precision = 0.1)
+        τ ~ Gamma(shape = 1.0, rate = 1.0)
         y .~ Normal(mean = μ, precision = τ)
     end
 
@@ -20,9 +20,9 @@
     end
 
     # Generate synthetic observations from a known distribution so the test is reproducible.
-    hidden_μ       = 3.1415
-    hidden_τ       = 2.7182
-    dataset        = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
+    hidden_μ = 3.1415
+    hidden_τ = 2.7182
+    dataset   = rand(StableRNG(42), NormalMeanPrecision(hidden_μ, hidden_τ), 25)
 
     # Run inference with `trace = true` so all internal events are recorded.
     # The trace is stored in the model metadata under the `:trace` key.
@@ -56,8 +56,8 @@ end
     # Both variables appear under `posteriors/*`, tagged with parameterization-specific names:
     # Normal → mean/precision, Gamma → shape/rate.
     @model function iid_estimation(y)
-        μ  ~ Normal(mean = 0.0, precision = 0.1)
-        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        μ ~ Normal(mean = 0.0, precision = 0.1)
+        τ ~ Gamma(shape = 1.0, rate = 1.0)
         y .~ Normal(mean = μ, precision = τ)
     end
 
@@ -98,8 +98,10 @@ end
         @test "posteriors/τ/rate" in all_tags
 
         # Verify we emitted one step per iteration for μ's mean and τ's shape.
-        @test length(steps_for_tag(log_dir, "posteriors/μ/mean"))  == n_iterations
-        @test length(steps_for_tag(log_dir, "posteriors/τ/shape")) == n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/μ/mean")) ==
+            n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/τ/shape")) ==
+            n_iterations
     end
 end
 
@@ -112,8 +114,8 @@ end
     # `posteriors/<var>/distribution`, which TensorBoard renders in both the
     # Distributions (percentile-band) and Histograms (ridgeline) dashboards.
     @model function iid_estimation(y)
-        μ  ~ Normal(mean = 0.0, precision = 0.1)
-        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        μ ~ Normal(mean = 0.0, precision = 0.1)
+        τ ~ Gamma(shape = 1.0, rate = 1.0)
         y .~ Normal(mean = μ, precision = τ)
     end
 
@@ -141,9 +143,12 @@ end
     trace = results.model.metadata[:trace]
 
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(trace; output_file = log_dir,
-                                              log_distributions = true,
-                                              n_samples = 512)
+        RxInfer.convert_to_tensorboard(
+            trace;
+            output_file = log_dir,
+            log_distributions = true,
+            n_samples = 512,
+        )
 
         all_tags = read_tags(log_dir)
 
@@ -152,8 +157,10 @@ end
         @test "posteriors/τ/distribution" in all_tags
 
         # One HistogramSummary per iteration for each variable.
-        @test length(steps_for_tag(log_dir, "posteriors/μ/distribution")) == n_iterations
-        @test length(steps_for_tag(log_dir, "posteriors/τ/distribution")) == n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/μ/distribution")) ==
+            n_iterations
+        @test length(steps_for_tag(log_dir, "posteriors/τ/distribution")) ==
+            n_iterations
 
         # Scalar tags must still be present — distributions complement, not replace, scalars.
         @test "posteriors/μ/mean" in all_tags
@@ -168,8 +175,8 @@ end
     # Guard-rail: with the default `log_distributions=false`, the new code path must be
     # inert — no `posteriors/*/distribution` tags should appear in the log.
     @model function iid_estimation(y)
-        μ  ~ Normal(mean = 0.0, precision = 0.1)
-        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        μ ~ Normal(mean = 0.0, precision = 0.1)
+        τ ~ Gamma(shape = 1.0, rate = 1.0)
         y .~ Normal(mean = μ, precision = τ)
     end
 
@@ -212,8 +219,8 @@ end
     # `EventCounts`) should appear. Flipping it to `true` must reinstate them
     # without disturbing scalar outputs (`iteration_time_ms`, `posteriors/*/*`).
     @model function iid_estimation(y)
-        μ  ~ Normal(mean = 0.0, precision = 0.1)
-        τ  ~ Gamma(shape = 1.0, rate = 1.0)
+        μ ~ Normal(mean = 0.0, precision = 0.1)
+        τ ~ Gamma(shape = 1.0, rate = 1.0)
         y .~ Normal(mean = μ, precision = τ)
     end
 
@@ -254,7 +261,9 @@ end
 
     # Opt-in: the full narrative layer comes back.
     with_safe_tempdir() do log_dir
-        RxInfer.convert_to_tensorboard(trace; output_file = log_dir, log_text_events = true)
+        RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, log_text_events = true
+        )
         all_tags = read_tags(log_dir)
         @test "Events" in all_tags
         @test "EventCounts" in all_tags


### PR DESCRIPTION
Adds `TensorBoardLoggerExt` — a package extension that converts RxInfer inference traces to TensorBoard event files via `RxInfer.convert_to_tensorboard`.
Logs per-iteration scalars (posterior mean/precision for Normal, shape/rate for Gamma, wall-clock `iteration_time_ms`), optional per-iteration histogram distributions, optional per-event text breadcrumbs, and an `EventCounts` summary.
Adds 5 `@testitem` tests covering the main code paths, plus a `helpers.jl` with Windows-safe tempdir cleanup and bypass readers that work around a `FieldError` in TensorBoardLogger 0.1.26's protobuf deserializer.

## Changed files

| File | Description |
|------|-------------|
| `ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl` | Refactored extension with `LogContext`, per-family scalar/histogram helpers, `log_distributions` and `log_text_events` flags, and `tb_append` write mode |
| `test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl` | Updated tests using new helpers |
| `test/ext/TensorBoardLoggerExt/helpers.jl` | **New file** — Windows-safe tempdir cleanup and bypass readers for TensorBoardLogger's broken deserializer |
| `CHANGELOG.md` | Unreleased section updated |

