### PR TITLE
redo the filtering of events PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+- The `trace = ...` keyword argument now accepts a tuple of symbols. In this case, 
+  only the events, whose names are present in the tuple will be traced.
+
 ## [5.1.0] - 2026-04-23
 
 ### Added

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -176,4 +176,5 @@ RxInfer.convert_to_tensorboard
 RxInferTraceCallbacks
 TracedEvent
 RxInfer.tracedevents
+RxInfer.is_trace_event_included
 ```

--- a/src/callbacks/trace.jl
+++ b/src/callbacks/trace.jl
@@ -20,15 +20,18 @@ end
 
 TracedEvent(event::Event) = TracedEvent(event, time_ns())
 
-Base.summary(io::IO, te::TracedEvent) = print(
+Base.show(io::IO, te::TracedEvent) = print(
     io, "TracedEvent(:$(event_name(typeof(te.event))))"
 )
 
 """
     RxInferTraceCallbacks()
 
-A callback structure that records all callback events during the inference procedure.
+A callback structure that records (optionally filtered) callback events during the inference procedure.
 Each event is stored as a [`TracedEvent`](@ref) wrapping the original event object.
+
+When constructed with no arguments (or `trace = true`), all events are recorded.
+When constructed with a tuple of `Symbol`s, only events whose names are in that tuple are recorded.
 
 After model creation, the trace callbacks instance is automatically saved into the model's metadata
 under the `:trace` key (i.e., `model.metadata[:trace]`), making it accessible from the inference result via
@@ -38,8 +41,11 @@ Use `RxInfer.tracedevents(callbacks)` to retrieve the vector of traced events.
 
 # Example
 ```julia
-# Create a trace callbacks instance
+# Create a trace callbacks instance that records all events
 trace = RxInferTraceCallbacks()
+
+# Or record only specific events
+trace = RxInferTraceCallbacks((:before_iteration, :after_iteration))
 
 result = infer(
     model = my_model(),
@@ -59,9 +65,41 @@ result.model.metadata[:trace] === trace # true
 """
 struct RxInferTraceCallbacks
     events::Vector{TracedEvent}
+    include::Union{Nothing, Set{Symbol}}
 end
 
-RxInferTraceCallbacks() = RxInferTraceCallbacks(TracedEvent[])
+RxInferTraceCallbacks() = RxInferTraceCallbacks(TracedEvent[], nothing)
+RxInferTraceCallbacks(include::NTuple{N, Symbol}) where {N} = RxInferTraceCallbacks(
+    TracedEvent[], Set{Symbol}(include)
+)
+
+"""
+    is_trace_event_included(callbacks::RxInferTraceCallbacks, event_name::Symbol)
+
+Checks whether the specified event is not filtered and should be traced.
+
+```@jldoctest 
+julia> callbacks = RxInfer.RxInferTraceCallbacks((:event1, :event2));
+
+julia> RxInfer.is_trace_event_included(callbacks, :event1)
+true
+
+julia> RxInfer.is_trace_event_included(callbacks, :event2)
+true
+
+julia> RxInfer.is_trace_event_included(callbacks, :event3)
+false
+```
+"""
+function is_trace_event_included(
+    callbacks::RxInferTraceCallbacks, event_name::Symbol
+)
+    if isnothing(callbacks.include)
+        return true
+    else
+        return event_name ∈ callbacks.include
+    end
+end
 
 """
     tracedevents(callbacks::RxInferTraceCallbacks)
@@ -117,9 +155,11 @@ end
 
 import ReactiveMP: handle_event, Event, event_name
 
-# Catch-all: trace every event
+# Catch-all: trace every event (respect the include filter)
 function ReactiveMP.handle_event(callbacks::RxInferTraceCallbacks, event::Event)
-    push!(callbacks.events, TracedEvent(event))
+    if is_trace_event_included(callbacks, event_name(event))
+        push!(callbacks.events, TracedEvent(event))
+    end
     return nothing
 end
 
@@ -130,12 +170,14 @@ function ReactiveMP.handle_event(
     if haskey(event.model.metadata, :trace)
         error(
             "The model's metadata already contains a `:trace` key. " *
-            "This can happen if you pass `trace = true` while also providing " *
+            "This can happen if you pass `trace = true` (or a tuple of event names) while also providing " *
             "`RxInferTraceCallbacks` in the `callbacks` argument. Use one or the other, not both.",
         )
     end
     event.model.metadata[:trace] = callbacks
-    push!(callbacks.events, TracedEvent(event))
+    if is_trace_event_included(callbacks, event_name(event))
+        push!(callbacks.events, TracedEvent(event))
+    end
     return nothing
 end
 

--- a/src/inference/inference.jl
+++ b/src/inference/inference.jl
@@ -561,7 +561,7 @@ Check the official documentation for more information about some of the argument
 - `autostart = true`: specifies whether to call `RxInfer.start` on the created engine automatically or not (exclusive for streamline inference)
 - `warn = true`: enables/disables warnings
 - `benchmark = false`: when set to `true`, automatically merges a [`RxInferBenchmarkCallbacks`](@ref) instance with the user-provided `callbacks`. The benchmark results are accessible via `result.model.metadata[:benchmark]`. See [Benchmark callbacks](@ref manual-inference-benchmark-callbacks).
-- `trace = false`: when set to `true`, automatically merges a [`RxInferTraceCallbacks`](@ref) instance with the user-provided `callbacks`. The trace results are accessible via `result.model.metadata[:trace]`. See [Trace callbacks](@ref manual-inference-trace-callbacks).
+- `trace = false`: when set to `true`, automatically merges a [`RxInferTraceCallbacks`](@ref) instance with the user-provided `callbacks`. Can also be a `Tuple` of `Symbol`s to trace only specific event types (e.g., `trace = (:before_iteration, :after_iteration)`). The trace results are accessible via `result.model.metadata[:trace]`. See [Trace callbacks](@ref manual-inference-trace-callbacks).
 - `session = RxInfer.default_session()`: current logging session for the RxInfer invokes, see `Session` for more details, pass `nothing` to disable logging
 
 ## Error hints
@@ -635,8 +635,13 @@ function infer(;
         callbacks = merge_callbacks(callbacks, RxInferBenchmarkCallbacks())
     end
 
-    if trace
-        callbacks = merge_callbacks(callbacks, RxInferTraceCallbacks())
+    if trace !== false
+        trace_callbacks = if trace === true
+            RxInferTraceCallbacks()
+        else
+            RxInferTraceCallbacks(trace)
+        end
+        callbacks = merge_callbacks(callbacks, trace_callbacks)
     end
 
     return with_session(session, :inference) do invoke

--- a/src/model/model.jl
+++ b/src/model/model.jl
@@ -42,6 +42,10 @@ struct ProbabilisticModel{M}
     metadata::Dict{Any, Any}
 end
 
+function Base.show(io::IO, ::ProbabilisticModel)
+    print(io, "ProbabilisticModel()")
+end
+
 ProbabilisticModel(model) = ProbabilisticModel(model, Dict{Any, Any}())
 
 "Returns the underlying factor graph model."

--- a/test/callbacks/trace_tests.jl
+++ b/test/callbacks/trace_tests.jl
@@ -48,7 +48,7 @@
         end
 
         init = @initialization begin
-            q(τ) = Gamma(1.0, 1.0)
+            q(τ) = Gamma(; shape = 1.0, rate = 1.0)
         end
 
         trace = RxInferTraceCallbacks()
@@ -217,6 +217,103 @@ end
     @test te.event isa BeforeModelCreationEvent
     @test event_name(typeof(te.event)) === :before_model_creation
 
-    # Test summary
-    @test sprint(summary, te) == "TracedEvent(:before_model_creation)"
+    # Test show
+    @test sprint(show, te) == "TracedEvent(:before_model_creation)"
+end
+
+@testitem "trace = (symbols...) should only record the requested event types" begin
+    using RxInfer
+    using ReactiveMP: event_name
+
+    @testset "The `include` option is respected inside `is_trace_event_included`" begin
+        callbacks = RxInfer.RxInferTraceCallbacks((:event1, :event2))
+
+        @test RxInfer.is_trace_event_included(callbacks, :event1)
+        @test RxInfer.is_trace_event_included(callbacks, :event2)
+        @test !RxInfer.is_trace_event_included(callbacks, :event3)
+    end
+
+    # Single-latent model: used where iteration events are not needed.
+    @model function trace_filter_simple_model(y)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = 0.0, precision = τ)
+    end
+
+    # Two-latent mean-field model: ensures before/after_iteration events fire.
+    @model function trace_filter_iter_model(y)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        x ~ Normal(; mean = 0.0, variance = 1.0)
+        y .~ Normal(; mean = x, precision = τ)
+    end
+
+    @constraints function trace_filter_iter_constraints()
+        q(x, τ) = q(x)q(τ)
+    end
+
+    iter_init = @initialization begin
+        q(τ) = Gamma(; shape = 1.0, rate = 1.0)
+    end
+
+    @testset "Only model-creation events are recorded when requested" begin
+        result = infer(;
+            model = trace_filter_simple_model(),
+            data = (y = [1.0, 2.0, 3.0],),
+            trace = (:before_model_creation, :after_model_creation),
+        )
+
+        trace = result.model.metadata[:trace]
+        @test trace isa RxInferTraceCallbacks
+
+        events = RxInfer.tracedevents(trace)
+        event_names = [event_name(typeof(e.event)) for e in events]
+
+        # Only the requested events should be present
+        @test all(
+            n -> n in (:before_model_creation, :after_model_creation),
+            event_names,
+        )
+        @test :before_model_creation in event_names
+        @test :after_model_creation in event_names
+
+        # Unrelated events must NOT appear
+        @test :before_inference ∉ event_names
+        @test :after_inference ∉ event_names
+    end
+
+    @testset "Only iteration events are recorded when requested" begin
+        result = infer(;
+            model = trace_filter_iter_model(),
+            data = (y = [1.0, 2.0, 3.0],),
+            iterations = 4,
+            initialization = iter_init,
+            constraints = trace_filter_iter_constraints(),
+            trace = (:before_iteration, :after_iteration),
+        )
+
+        trace = result.model.metadata[:trace]
+        events = RxInfer.tracedevents(trace)
+        event_names = [event_name(typeof(e.event)) for e in events]
+
+        # Only iteration events should be present
+        @test all(n -> n in (:before_iteration, :after_iteration), event_names)
+        @test count(==(:before_iteration), event_names) == 4
+        @test count(==(:after_iteration), event_names) == 4
+
+        # Model-creation and inference-level events must NOT appear
+        @test :before_model_creation ∉ event_names
+        @test :after_model_creation ∉ event_names
+        @test :before_inference ∉ event_names
+        @test :after_inference ∉ event_names
+    end
+
+    @testset "Empty tuple records no events" begin
+        result = infer(;
+            model = trace_filter_simple_model(),
+            data = (y = [1.0, 2.0, 3.0],),
+            trace = (),
+        )
+
+        trace = result.model.metadata[:trace]
+        @test isempty(RxInfer.tracedevents(trace))
+    end
 end


### PR DESCRIPTION
I merged the https://github.com/ReactiveBayes/RxInfer.jl/pull/633/ from @ofSingularMind into a deleted branch and didnt noticed it. This PR re-implements the PR from @ofSingularMind since I couldn't figure out how to fix it properly. Re-copypasting everything seemed like an easier solution. All the credits to @ofSingularMind 