### PR TITLE
feat: expand TensorBoardLoggerExt univariate posterior coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), and `InverseGamma` / `GammaInverse` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+
 ## [5.2.0] - 2026-04-24
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), and `Exponential` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), and `Exponential` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), and `Laplace` (location/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), `Pareto` (shape/scale), and `Rayleigh` (scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), `Pareto` (shape/scale), `Rayleigh` (scale), and `Chisq` (dof). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), and `InverseGamma` / `GammaInverse` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), and `Poisson` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), and `Laplace` (location/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), and `Pareto` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), and `NegativeBinomial` (r/succprob). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), and `Exponential` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), and `Geometric` (succprob). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), and `NegativeBinomial` (r/succprob). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), and `Weibull` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), and `LogNormal` (meanlog/stdlog). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), and `Poisson` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), and `Geometric` (succprob). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), and `Exponential` (rate). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), and `VonMises` (location/concentration). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), and `LogNormal` (meanlog/stdlog). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), and `VonMises` (location/concentration). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), and `Weibull` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), `Pareto` (shape/scale), `Rayleigh` (scale), and `Chisq` (dof). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `RxInfer.convert_to_tensorboard` accepts a new `log_posteriors` keyword that filters which marginals reach the `posteriors/*` tags. Pass `false` to suppress every posterior tag (scalars and histograms), `true` (default) to keep current behaviour, or a `Vector{String}` / `Vector{Symbol}` allow-list (e.g. `["μ"]` or `[:μ]`) to log only the named variables. Iteration timing, event counts, and event-text breadcrumbs are unaffected by the filter.
 
 ## [5.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), and `Pareto` (shape/scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
+- `TensorBoardLoggerExt` posterior scalar logging now covers more univariate families. In addition to `Normal` (mean/precision) and `Gamma` (shape/rate), it now emits parameterisation-aware tags for `Beta` (alpha/beta/mean), `Bernoulli` (succprob), `Binomial` (ntrials/succprob), `InverseGamma` / `GammaInverse` (shape/scale), `Poisson` (rate), `Geometric` (succprob), `NegativeBinomial` (r/succprob), `Exponential` (rate), `VonMises` (location/concentration), `Weibull` (shape/scale), `LogNormal` (meanlog/stdlog), and `Erlang` (shape/scale), `Laplace` (location/scale), `Pareto` (shape/scale), and `Rayleigh` (scale). Any remaining `UnivariateDistribution` falls back to generic `mean` and `var` tags so unknown posteriors still produce visible convergence traces.
 
 ## [5.2.0] - 2026-04-24
 

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -161,10 +161,37 @@ log_dir = RxInfer.convert_to_tensorboard(trace; log_distributions = true)
 | Output | TensorBoard tab | Condition |
 |--------|----------------|-----------|
 | Per-iteration wall-clock duration (`iteration_time_ms`) | Scalars | always |
-| `mean` / `precision` for each Normal posterior | Scalars | always |
-| `shape` / `rate` for each Gamma posterior | Scalars | always |
-| Per-iteration histogram of posterior samples | Distributions / Histograms | `log_distributions = true` |
+| Parameterisation-aware scalar tags for each posterior (see table below) | Scalars | always |
+| Per-iteration histogram of posterior samples (`posteriors/<var>/distribution`) | Distributions / Histograms | `log_distributions = true` |
 | Event breadcrumbs and `EventCounts` table | Text | `log_text_events = true` (counts always written) |
+
+#### Posterior scalar tags by family
+
+Each posterior is logged under `posteriors/<variable>/<tag>` with one step per inference iteration. Specific dispatch is selected by the marginal's distribution type — the most-specific method wins, with the generic `mean`/`var` fallback catching anything not listed.
+
+| Distribution family | Emitted tags |
+|---|---|
+| `Normal` (any of the `UnivariateNormalDistributionsFamily` aliases) | `mean`, `precision` |
+| `Gamma` (any of the `GammaDistributionsFamily` aliases) | `shape`, `rate` |
+| `Beta` | `alpha`, `beta`, `mean` |
+| `Bernoulli` | `succprob` |
+| `Binomial` | `ntrials`, `succprob` |
+| `InverseGamma` (a.k.a. `GammaInverse`) | `shape`, `scale` |
+| `Poisson` | `rate` |
+| `Geometric` | `succprob` |
+| `NegativeBinomial` | `r`, `succprob` |
+| `Exponential` | `rate` |
+| `VonMises` | `location`, `concentration` |
+| `Weibull` | `shape`, `scale` |
+| `LogNormal` | `meanlog`, `stdlog` |
+| `Erlang` | `shape`, `scale` |
+| `Laplace` | `location`, `scale` |
+| `Pareto` | `shape`, `scale` |
+| `Rayleigh` | `scale` |
+| `Chisq` | `dof` |
+| any other `UnivariateDistribution` (fallback) | `mean`, `var` |
+
+Marginals that are not univariate (e.g. multivariate Normal, matrix-variate posteriors) are silently skipped on the scalar path and produce no `posteriors/...` scalar tags. The histogram path is also gated on `<: UnivariateDistribution`, so the same families above are the ones that contribute to the Distributions / Histograms tabs when `log_distributions = true`.
 
 ```@docs 
 RxInfer.convert_to_tensorboard

--- a/docs/src/manuals/inference/trace-callbacks.md
+++ b/docs/src/manuals/inference/trace-callbacks.md
@@ -161,8 +161,8 @@ log_dir = RxInfer.convert_to_tensorboard(trace; log_distributions = true)
 | Output | TensorBoard tab | Condition |
 |--------|----------------|-----------|
 | Per-iteration wall-clock duration (`iteration_time_ms`) | Scalars | always |
-| Parameterisation-aware scalar tags for each posterior (see table below) | Scalars | always |
-| Per-iteration histogram of posterior samples (`posteriors/<var>/distribution`) | Distributions / Histograms | `log_distributions = true` |
+| Parameterisation-aware scalar tags for each posterior (see table below) | Scalars | `log_posteriors` admits the variable (see [Filtering posteriors](@ref tensorboard-log-posteriors)) |
+| Per-iteration histogram of posterior samples (`posteriors/<var>/distribution`) | Distributions / Histograms | `log_distributions = true` **and** `log_posteriors` admits the variable |
 | Event breadcrumbs and `EventCounts` table | Text | `log_text_events = true` (counts always written) |
 
 #### Posterior scalar tags by family
@@ -192,6 +192,32 @@ Each posterior is logged under `posteriors/<variable>/<tag>` with one step per i
 | any other `UnivariateDistribution` (fallback) | `mean`, `var` |
 
 Marginals that are not univariate (e.g. multivariate Normal, matrix-variate posteriors) are silently skipped on the scalar path and produce no `posteriors/...` scalar tags. The histogram path is also gated on `<: UnivariateDistribution`, so the same families above are the ones that contribute to the Distributions / Histograms tabs when `log_distributions = true`.
+
+### [Filtering posteriors](@id tensorboard-log-posteriors)
+
+The `log_posteriors` keyword controls **which** marginals reach the `posteriors/<var>/*` tags. It is independent of `log_distributions`, which controls **what** is emitted (scalars only vs. scalars + per-iteration histogram). Think of `log_posteriors` as the row filter and `log_distributions` as the column filter.
+
+| `log_posteriors` value | Effect |
+|---|---|
+| `true` *(default)* | Log every marginal the model produces. |
+| `false` | Suppress every `posteriors/*` tag (both scalars and histograms). Iteration timing, event counts, and event-text breadcrumbs are unaffected. |
+| `Vector{String}` or `Vector{Symbol}` | Log only marginals whose name appears in the list. Both `["μ", "θ"]` and `[:μ, :θ]` are accepted. An empty list behaves like `false`. |
+
+```julia
+trace = result.model.metadata[:trace]
+
+# Log only μ (the τ posterior is skipped on both scalar and histogram paths).
+RxInfer.convert_to_tensorboard(
+    trace;
+    log_posteriors    = ["μ"],
+    log_distributions = true,
+)
+
+# Suppress every posterior tag while keeping iteration timing visible.
+RxInfer.convert_to_tensorboard(trace; log_posteriors = false)
+```
+
+When `log_posteriors` is an allow-list, the per-event text breadcrumb under `on_marginal_update/<var>` (gated by `log_text_events`) still fires for every variable — so you can keep visibility on which marginals updated without paying the scalar/histogram cost.
 
 ```@docs 
 RxInfer.convert_to_tensorboard

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, shape, rate
+using Distributions: UnivariateDistribution, Beta, Bernoulli, shape, rate, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -82,6 +82,29 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Beta, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    α, β = params(dist)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/alpha", α; step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/beta", β; step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/mean", α / (α + β); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Bernoulli, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
     )
 end
 _log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, NegativeBinomial, shape, rate, scale, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, shape, rate, scale, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -144,6 +144,14 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Exponential, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, shape, rate, scale, params, succprob, ntrials, location
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, Rayleigh, shape, rate, scale, params, succprob, ntrials, location
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -229,6 +229,14 @@ function _log_posterior_scalars!(
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
     )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Rayleigh, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, shape, rate, scale, params, succprob, ntrials
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, shape, rate, scale, params, succprob, ntrials
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -186,6 +186,18 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::LogNormal, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    meanlog, stdlog = params(dist)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/meanlog", meanlog; step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/stdlog", stdlog; step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, shape, rate, scale, params, succprob, ntrials
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, shape, rate, scale, params, succprob, ntrials
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -175,6 +175,17 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/concentration", κ; step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Weibull, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, shape, rate, scale, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, shape, rate, scale, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -116,6 +116,14 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Poisson, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -101,8 +101,9 @@ LogContext(logger; log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, Ab
 # Events that need `ev.variable.label` or a renamed label (e.g.
 # `OnMarginalUpdateEvent`'s `variable: $(ev.variable_name)`) build the
 # string inline.
-@inline _format_fields(ev, fields::NTuple{N, Symbol}) where {N} =
-    join(("$(f): $(getfield(ev, f))" for f in fields), " | ")
+@inline _format_fields(ev, fields::NTuple{N, Symbol}) where {N} = join(
+    ("$(f): $(getfield(ev, f))" for f in fields), " | "
+)
 
 # ─── Distribution-family dispatched helpers ──────────────────────────────
 # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
@@ -121,11 +122,13 @@ _posterior_samples(::Any, ::Int)                         = Float64[]
 # shows convergence behaviour in TensorBoard).
 _posterior_tags(::Any) = nothing
 
-_posterior_tags(d::UnivariateNormalDistributionsFamily) =
-    (mean = mean(d), precision = inv(var(d)))
+_posterior_tags(d::UnivariateNormalDistributionsFamily) = (
+    mean = mean(d), precision = inv(var(d))
+)
 
-_posterior_tags(d::GammaDistributionsFamily) =
-    (shape = shape(d), rate = rate(d))
+_posterior_tags(d::GammaDistributionsFamily) = (
+    shape = shape(d), rate = rate(d)
+)
 
 function _posterior_tags(d::Beta)
     α, β = params(d)
@@ -204,7 +207,8 @@ _log_posterior_distribution!(::LogContext, ::Any, ::Symbol) = nothing
 
 function log_event(ctx::LogContext, ev::BeforeModelCreationEvent, idx)
     _log_text!(
-        ctx, "before_model_creation",
+        ctx,
+        "before_model_creation",
         _format_fields(ev, (:span_id,));
         step = idx,
     )
@@ -212,7 +216,8 @@ end
 
 function log_event(ctx::LogContext, ev::AfterModelCreationEvent, idx)
     _log_text!(
-        ctx, "after_model_creation",
+        ctx,
+        "after_model_creation",
         _format_fields(ev, (:model, :span_id));
         step = idx,
     )
@@ -220,7 +225,8 @@ end
 
 function log_event(ctx::LogContext, ev::BeforeInferenceEvent, idx)
     _log_text!(
-        ctx, "before_inference",
+        ctx,
+        "before_inference",
         _format_fields(ev, (:model, :span_id));
         step = idx,
     )
@@ -228,7 +234,8 @@ end
 
 function log_event(ctx::LogContext, ev::AfterInferenceEvent, idx)
     _log_text!(
-        ctx, "after_inference",
+        ctx,
+        "after_inference",
         _format_fields(ev, (:model, :span_id));
         step = idx,
     )
@@ -239,7 +246,8 @@ end
 # in-line as events stream by, via `ctx.current_time_ns`.
 function log_event(ctx::LogContext, ev::BeforeIterationEvent, _idx)
     _log_text!(
-        ctx, "before_iteration",
+        ctx,
+        "before_iteration",
         _format_fields(ev, (:model, :iteration, :stop_iteration, :span_id));
         step = ev.iteration,
     )
@@ -250,7 +258,8 @@ end
 # `span_id` to compute and log the iteration's wall-clock duration.
 function log_event(ctx::LogContext, ev::AfterIterationEvent, _idx)
     _log_text!(
-        ctx, "after_iteration",
+        ctx,
+        "after_iteration",
         _format_fields(ev, (:model, :iteration, :stop_iteration, :span_id));
         step = ev.iteration,
     )
@@ -266,7 +275,8 @@ end
 
 function log_event(ctx::LogContext, ev::BeforeDataUpdateEvent, idx)
     _log_text!(
-        ctx, "before_data_update",
+        ctx,
+        "before_data_update",
         _format_fields(ev, (:model, :data, :span_id));
         step = idx,
     )
@@ -274,7 +284,8 @@ end
 
 function log_event(ctx::LogContext, ev::AfterDataUpdateEvent, idx)
     _log_text!(
-        ctx, "after_data_update",
+        ctx,
+        "after_data_update",
         _format_fields(ev, (:model, :data, :span_id));
         step = idx,
     )
@@ -321,7 +332,8 @@ end
 
 function log_event(ctx::LogContext, ev::BeforeAutostartEvent, idx)
     _log_text!(
-        ctx, "before_autostart",
+        ctx,
+        "before_autostart",
         _format_fields(ev, (:engine, :span_id));
         step = idx,
     )
@@ -329,7 +341,8 @@ end
 
 function log_event(ctx::LogContext, ev::AfterAutostartEvent, idx)
     _log_text!(
-        ctx, "after_autostart",
+        ctx,
+        "after_autostart",
         _format_fields(ev, (:engine, :span_id));
         step = idx,
     )
@@ -339,7 +352,8 @@ function log_event(
     ctx::LogContext, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx
 )
     _log_text!(
-        ctx, "before_message_rule_call",
+        ctx,
+        "before_message_rule_call",
         _format_fields(ev, (:mapping, :messages, :marginals, :span_id));
         step = idx,
     )
@@ -349,7 +363,8 @@ function log_event(
     ctx::LogContext, ev::ReactiveMP.AfterMessageRuleCallEvent, idx
 )
     _log_text!(
-        ctx, "after_message_rule_call",
+        ctx,
+        "after_message_rule_call",
         _format_fields(
             ev,
             (:mapping, :messages, :marginals, :result, :annotations, :span_id),
@@ -449,7 +464,8 @@ end
 # Fallback for unknown event types
 function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
     _log_text!(
-        ctx, "unknown_events",
+        ctx,
+        "unknown_events",
         "event_type: $(event_name(typeof(ev)))";
         step = idx,
     )

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, shape, rate, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, shape, rate, scale, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -105,6 +105,31 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::InverseGamma, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+# Generic moment fallback: any UnivariateDistribution we haven't special-cased
+# still gets `mean`/`var` tags so TensorBoard shows convergence behaviour
+# instead of going silent. More-specific methods above take precedence.
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::UnivariateDistribution, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/mean", mean(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/var", var(dist); step = step
     )
 end
 _log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, shape, rate, scale, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, shape, rate, scale, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -124,6 +124,14 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Geometric, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,32 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, Rayleigh, Chisq, shape, rate, scale, params, succprob, ntrials, location, dof
+using Distributions:
+    UnivariateDistribution,
+    Beta,
+    Bernoulli,
+    Binomial,
+    InverseGamma,
+    Poisson,
+    Geometric,
+    NegativeBinomial,
+    Exponential,
+    VonMises,
+    Weibull,
+    LogNormal,
+    Erlang,
+    Laplace,
+    Pareto,
+    Rayleigh,
+    Chisq,
+    shape,
+    rate,
+    scale,
+    params,
+    succprob,
+    ntrials,
+    location,
+    dof
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -84,9 +109,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Beta, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Beta, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     α, β = params(dist)
     TensorBoardLogger.log_value(
@@ -99,17 +122,13 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/mean", α / (α + β); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Bernoulli, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Bernoulli, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Binomial, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Binomial, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/ntrials", ntrials(dist); step = step
@@ -129,17 +148,13 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Poisson, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Poisson, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Geometric, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Geometric, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
@@ -165,9 +180,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::VonMises, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::VonMises, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     μ, κ = params(dist)
     TensorBoardLogger.log_value(
@@ -177,9 +190,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/concentration", κ; step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Weibull, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Weibull, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
@@ -188,9 +199,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::LogNormal, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::LogNormal, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     meanlog, stdlog = params(dist)
     TensorBoardLogger.log_value(
@@ -200,9 +209,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/stdlog", stdlog; step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Erlang, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Erlang, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
@@ -211,9 +218,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Laplace, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Laplace, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/location", location(dist); step = step
@@ -222,9 +227,7 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Pareto, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Pareto, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
@@ -233,17 +236,13 @@ function _log_posterior_scalars!(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Rayleigh, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Rayleigh, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Chisq, name::Symbol
-)
+function _log_posterior_scalars!(ctx::LogContext, dist::Chisq, name::Symbol)
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/dof", dof(dist); step = step

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -65,13 +65,7 @@ end
 _normalize_posteriors(p::Bool) = p
 _normalize_posteriors(v::AbstractVector) = Set{Symbol}(Symbol(x) for x in v)
 
-LogContext(
-    logger;
-    log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, AbstractString}}} = true,
-    log_distributions::Bool,
-    log_text_events::Bool,
-    n_samples::Int,
-) = LogContext(
+LogContext(logger; log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, AbstractString}}} = true, log_distributions::Bool, log_text_events::Bool, n_samples::Int) = LogContext(
     logger,
     Dict{Int, Float64}(),
     Dict{Any, Tuple{Int, UInt64}}(),
@@ -95,10 +89,11 @@ LogContext(
 # the runtime type of `log_posteriors`: `Bool` is the global on/off, and
 # `Set{Symbol}` restricts logging to an explicit allow-list of variable
 # names. Empty set behaves like `false` (logs nothing).
-@inline _should_log_posterior(ctx::LogContext, name::Symbol) =
-    _check_posterior(ctx.log_posteriors, name)
-@inline _check_posterior(flag::Bool, ::Symbol)             = flag
-@inline _check_posterior(allowed::Set{Symbol}, n::Symbol)  = n in allowed
+@inline _should_log_posterior(ctx::LogContext, name::Symbol) = _check_posterior(
+    ctx.log_posteriors, name
+)
+@inline _check_posterior(flag::Bool, ::Symbol) = flag
+@inline _check_posterior(allowed::Set{Symbol}, n::Symbol) = n in allowed
 
 # ─── Distribution-family dispatched helpers ──────────────────────────────
 # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
@@ -571,7 +566,9 @@ end
 function RxInfer.convert_to_tensorboard(
     trace::RxInferTraceCallbacks;
     output_file::Union{String, Nothing} = nothing,
-    log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, AbstractString}}} = true,
+    log_posteriors::Union{
+        Bool, AbstractVector{<:Union{Symbol, AbstractString}}
+    } = true,
     log_distributions::Bool = false,
     log_text_events::Bool = false,
     n_samples::Int = 1024,

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, shape, rate, scale, params, succprob, ntrials, location
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, shape, rate, scale, params, succprob, ntrials, location
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -217,6 +217,17 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/location", location(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Pareto, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, shape, rate, scale, params, succprob, ntrials
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, shape, rate, scale, params, succprob, ntrials
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -198,6 +198,17 @@ function _log_posterior_scalars!(
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/stdlog", stdlog; step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Erlang, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, Rayleigh, shape, rate, scale, params, succprob, ntrials, location
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, Pareto, Rayleigh, Chisq, shape, rate, scale, params, succprob, ntrials, location, dof
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -239,6 +239,14 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Chisq, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/dof", dof(dist); step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, shape, rate, scale, params, succprob, ntrials
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, shape, rate, scale, params, succprob, ntrials
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -163,6 +163,18 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::VonMises, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    μ, κ = params(dist)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/location", μ; step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/concentration", κ; step = step
     )
 end
 # Generic moment fallback: any UnivariateDistribution we haven't special-cased

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, shape, rate, scale, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, shape, rate, scale, params, succprob, ntrials
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -103,6 +103,17 @@ function _log_posterior_scalars!(
     ctx::LogContext, dist::Bernoulli, name::Symbol
 )
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Binomial, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/ntrials", ntrials(dist); step = step
+    )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
     )

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, shape, rate, scale, params, succprob
+using Distributions: UnivariateDistribution, Beta, Bernoulli, InverseGamma, Poisson, Geometric, NegativeBinomial, shape, rate, scale, params, succprob
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -130,6 +130,18 @@ function _log_posterior_scalars!(
     ctx::LogContext, dist::Geometric, name::Symbol
 )
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::NegativeBinomial, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    r, _ = params(dist)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/r", r; step = step
+    )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
     )

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -51,18 +51,33 @@ mutable struct LogContext{L}
     before_times::Dict{Any, Tuple{Int, UInt64}}
     counts::Dict{Symbol, Int}
     posterior_step::Dict{Symbol, Int}
+    log_posteriors::Union{Bool, Set{Symbol}}
     log_distributions::Bool
     log_text_events::Bool
     n_samples::Int
     current_time_ns::UInt64
 end
 
-LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::Int) = LogContext(
+# Normalize the user-facing `log_posteriors` value to the internal
+# representation. `Bool` passes through; any vector of names is collapsed
+# into a `Set{Symbol}` so per-event filtering is O(1) and accepts either
+# `String` (`["μ", "θ"]`) or `Symbol` (`[:μ, :θ]`) inputs interchangeably.
+_normalize_posteriors(p::Bool) = p
+_normalize_posteriors(v::AbstractVector) = Set{Symbol}(Symbol(x) for x in v)
+
+LogContext(
+    logger;
+    log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, AbstractString}}} = true,
+    log_distributions::Bool,
+    log_text_events::Bool,
+    n_samples::Int,
+) = LogContext(
     logger,
     Dict{Int, Float64}(),
     Dict{Any, Tuple{Int, UInt64}}(),
     Dict{Symbol, Int}(),
     Dict{Symbol, Int}(),
+    _normalize_posteriors(log_posteriors),
     log_distributions,
     log_text_events,
     n_samples,
@@ -75,6 +90,15 @@ LogContext(logger; log_distributions::Bool, log_text_events::Bool, n_samples::In
 @inline _log_text!(ctx::LogContext, tag, msg; step) =
     ctx.log_text_events &&
     TensorBoardLogger.log_text(ctx.logger, tag, msg; step = step)
+
+# Per-variable gate for posterior scalar + histogram logging. Dispatches on
+# the runtime type of `log_posteriors`: `Bool` is the global on/off, and
+# `Set{Symbol}` restricts logging to an explicit allow-list of variable
+# names. Empty set behaves like `false` (logs nothing).
+@inline _should_log_posterior(ctx::LogContext, name::Symbol) =
+    _check_posterior(ctx.log_posteriors, name)
+@inline _check_posterior(flag::Bool, ::Symbol)             = flag
+@inline _check_posterior(allowed::Set{Symbol}, n::Symbol)  = n in allowed
 
 # ─── Distribution-family dispatched helpers ──────────────────────────────
 # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
@@ -378,6 +402,7 @@ function log_event(ctx::LogContext, ev::OnMarginalUpdateEvent, idx)
         "model: $(ev.model) | variable: $(ev.variable_name) | update: $(ev.update)";
         step = idx,
     )
+    _should_log_posterior(ctx, ev.variable_name) || return nothing
     dist = try
         getdata(ev.update)
     catch err
@@ -546,6 +571,7 @@ end
 function RxInfer.convert_to_tensorboard(
     trace::RxInferTraceCallbacks;
     output_file::Union{String, Nothing} = nothing,
+    log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, AbstractString}}} = true,
     log_distributions::Bool = false,
     log_text_events::Bool = false,
     n_samples::Int = 1024,
@@ -571,7 +597,7 @@ function RxInfer.convert_to_tensorboard(
     log_subdir = joinpath(output_file, format(now(), "yyyy-mm-dd_HH-MM-SS"))
     mkpath(log_subdir)
     logger = TBLogger(log_subdir, tb_append)
-    ctx    = LogContext(logger; log_distributions = log_distributions, log_text_events = log_text_events, n_samples = n_samples)
+    ctx    = LogContext(logger; log_posteriors = log_posteriors, log_distributions = log_distributions, log_text_events = log_text_events, n_samples = n_samples)
 
     for (idx, traced) in enumerate(events)
         ev                  = traced.event

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -4,7 +4,7 @@ using RxInfer
 using ReactiveMP: event_name, getdata
 using ExponentialFamily:
     UnivariateNormalDistributionsFamily, GammaDistributionsFamily
-using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, shape, rate, scale, params, succprob, ntrials
+using Distributions: UnivariateDistribution, Beta, Bernoulli, Binomial, InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises, Weibull, LogNormal, Erlang, Laplace, shape, rate, scale, params, succprob, ntrials, location
 using Dates: now, format
 using Random: MersenneTwister
 using Statistics: mean, var
@@ -206,6 +206,17 @@ function _log_posterior_scalars!(
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
+    )
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
+    )
+end
+function _log_posterior_scalars!(
+    ctx::LogContext, dist::Laplace, name::Symbol
+)
+    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
+    TensorBoardLogger.log_value(
+        ctx.logger, "posteriors/$(name)/location", location(dist); step = step
     )
     TensorBoardLogger.log_value(
         ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step

--- a/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
+++ b/ext/TensorBoardLoggerExt/TensorBoardLoggerExt.jl
@@ -95,6 +95,15 @@ LogContext(logger; log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, Ab
 @inline _check_posterior(flag::Bool, ::Symbol) = flag
 @inline _check_posterior(allowed::Set{Symbol}, n::Symbol) = n in allowed
 
+# Pipe-delimited `"k1: v1 | k2: v2 | ..."` formatter for text-event
+# breadcrumbs. Reads each named field via `getfield(ev, f)`, so this helper
+# only fits events where every logged value is a direct field access.
+# Events that need `ev.variable.label` or a renamed label (e.g.
+# `OnMarginalUpdateEvent`'s `variable: $(ev.variable_name)`) build the
+# string inline.
+@inline _format_fields(ev, fields::NTuple{N, Symbol}) where {N} =
+    join(("$(f): $(getfield(ev, f))" for f in fields), " | ")
+
 # ─── Distribution-family dispatched helpers ──────────────────────────────
 # Deterministic samples via a seeded MersenneTwister keep the HistogramSummary
 # reproducible across re-runs. The `::Any` fallback returns an empty vector
@@ -103,185 +112,77 @@ LogContext(logger; log_posteriors::Union{Bool, AbstractVector{<:Union{Symbol, Ab
 _posterior_samples(dist::UnivariateDistribution, n::Int) = rand(MersenneTwister(1), dist, n)
 _posterior_samples(::Any, ::Int)                         = Float64[]
 
-# Scalar-posterior logging, dispatched on the distribution family's natural
-# parameterisation. Mutates `ctx.posterior_step` so the per-variable step
-# counter stays aligned with the distribution-summary step.
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::UnivariateNormalDistributionsFamily, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/mean", mean(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/precision", inv(var(dist)); step = step
-    )
+# Per-distribution scalar tag table. Returns a `NamedTuple` of
+# `(tag => value)` pairs to log under `posteriors/<name>/<tag>`.
+# `nothing` means "skip this variable" — distinct from an empty NamedTuple,
+# which would still bump the step counter. Family-specific methods take
+# precedence over the `UnivariateDistribution` generic fallback (which
+# logs `mean` and `var` so any unspecialised univariate marginal still
+# shows convergence behaviour in TensorBoard).
+_posterior_tags(::Any) = nothing
+
+_posterior_tags(d::UnivariateNormalDistributionsFamily) =
+    (mean = mean(d), precision = inv(var(d)))
+
+_posterior_tags(d::GammaDistributionsFamily) =
+    (shape = shape(d), rate = rate(d))
+
+function _posterior_tags(d::Beta)
+    α, β = params(d)
+    return (alpha = α, beta = β, mean = α / (α + β))
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::GammaDistributionsFamily, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
-    )
+
+_posterior_tags(d::Bernoulli) = (succprob = succprob(d),)
+_posterior_tags(d::Binomial) = (ntrials = ntrials(d), succprob = succprob(d))
+_posterior_tags(d::InverseGamma) = (shape = shape(d), scale = scale(d))
+_posterior_tags(d::Poisson) = (rate = rate(d),)
+_posterior_tags(d::Geometric) = (succprob = succprob(d),)
+
+function _posterior_tags(d::NegativeBinomial)
+    r, _ = params(d)
+    return (r = r, succprob = succprob(d))
 end
-function _log_posterior_scalars!(ctx::LogContext, dist::Beta, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    α, β = params(dist)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/alpha", α; step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/beta", β; step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/mean", α / (α + β); step = step
-    )
+
+_posterior_tags(d::Exponential) = (rate = rate(d),)
+
+function _posterior_tags(d::VonMises)
+    μ, κ = params(d)
+    return (location = μ, concentration = κ)
 end
-function _log_posterior_scalars!(ctx::LogContext, dist::Bernoulli, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
-    )
+
+_posterior_tags(d::Weibull) = (shape = shape(d), scale = scale(d))
+
+function _posterior_tags(d::LogNormal)
+    meanlog, stdlog = params(d)
+    return (meanlog = meanlog, stdlog = stdlog)
 end
-function _log_posterior_scalars!(ctx::LogContext, dist::Binomial, name::Symbol)
+
+_posterior_tags(d::Erlang) = (shape = shape(d), scale = scale(d))
+_posterior_tags(d::Laplace) = (location = location(d), scale = scale(d))
+_posterior_tags(d::Pareto) = (shape = shape(d), scale = scale(d))
+_posterior_tags(d::Rayleigh) = (scale = scale(d),)
+_posterior_tags(d::Chisq) = (dof = dof(d),)
+
+# Generic moment fallback: any UnivariateDistribution we haven't
+# special-cased still gets `mean`/`var` tags so TensorBoard shows
+# convergence behaviour instead of going silent.
+_posterior_tags(d::UnivariateDistribution) = (mean = mean(d), var = var(d))
+
+# Scalar-posterior logging delegates to `_posterior_tags(dist)` and writes
+# each `(tag => value)` pair under `posteriors/<name>/<tag>`. The step
+# counter is bumped only when there is at least one tag to log, so
+# unsupported distributions don't desync the per-variable step.
+function _log_posterior_scalars!(ctx::LogContext, dist, name::Symbol)
+    tags = _posterior_tags(dist)
+    tags === nothing && return nothing
     step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/ntrials", ntrials(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
-    )
+    for (tag, value) in pairs(tags)
+        TensorBoardLogger.log_value(
+            ctx.logger, "posteriors/$(name)/$(tag)", value; step = step
+        )
+    end
+    return nothing
 end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::InverseGamma, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Poisson, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Geometric, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
-    )
-end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::NegativeBinomial, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    r, _ = params(dist)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/r", r; step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/succprob", succprob(dist); step = step
-    )
-end
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::Exponential, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/rate", rate(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::VonMises, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    μ, κ = params(dist)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/location", μ; step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/concentration", κ; step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Weibull, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::LogNormal, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    meanlog, stdlog = params(dist)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/meanlog", meanlog; step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/stdlog", stdlog; step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Erlang, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Laplace, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/location", location(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Pareto, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/shape", shape(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Rayleigh, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/scale", scale(dist); step = step
-    )
-end
-function _log_posterior_scalars!(ctx::LogContext, dist::Chisq, name::Symbol)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/dof", dof(dist); step = step
-    )
-end
-# Generic moment fallback: any UnivariateDistribution we haven't special-cased
-# still gets `mean`/`var` tags so TensorBoard shows convergence behaviour
-# instead of going silent. More-specific methods above take precedence.
-function _log_posterior_scalars!(
-    ctx::LogContext, dist::UnivariateDistribution, name::Symbol
-)
-    step = (ctx.posterior_step[name] = get(ctx.posterior_step, name, 0) + 1)
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/mean", mean(dist); step = step
-    )
-    TensorBoardLogger.log_value(
-        ctx.logger, "posteriors/$(name)/var", var(dist); step = step
-    )
-end
-_log_posterior_scalars!(::LogContext, ::Any, ::Symbol) = nothing
 
 # Per-iteration HistogramSummary. The data-only `log_histogram` overload
 # lets TB auto-bin each iteration's samples so HistogramProto.min/max track
@@ -303,33 +204,32 @@ _log_posterior_distribution!(::LogContext, ::Any, ::Symbol) = nothing
 
 function log_event(ctx::LogContext, ev::BeforeModelCreationEvent, idx)
     _log_text!(
-        ctx, "before_model_creation", "span_id: $(ev.span_id)"; step = idx
+        ctx, "before_model_creation",
+        _format_fields(ev, (:span_id,));
+        step = idx,
     )
 end
 
 function log_event(ctx::LogContext, ev::AfterModelCreationEvent, idx)
     _log_text!(
-        ctx,
-        "after_model_creation",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
+        ctx, "after_model_creation",
+        _format_fields(ev, (:model, :span_id));
         step = idx,
     )
 end
 
 function log_event(ctx::LogContext, ev::BeforeInferenceEvent, idx)
     _log_text!(
-        ctx,
-        "before_inference",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
+        ctx, "before_inference",
+        _format_fields(ev, (:model, :span_id));
         step = idx,
     )
 end
 
 function log_event(ctx::LogContext, ev::AfterInferenceEvent, idx)
     _log_text!(
-        ctx,
-        "after_inference",
-        "model: $(ev.model) | span_id: $(ev.span_id)";
+        ctx, "after_inference",
+        _format_fields(ev, (:model, :span_id));
         step = idx,
     )
 end
@@ -339,9 +239,8 @@ end
 # in-line as events stream by, via `ctx.current_time_ns`.
 function log_event(ctx::LogContext, ev::BeforeIterationEvent, _idx)
     _log_text!(
-        ctx,
-        "before_iteration",
-        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
+        ctx, "before_iteration",
+        _format_fields(ev, (:model, :iteration, :stop_iteration, :span_id));
         step = ev.iteration,
     )
     ctx.before_times[ev.span_id] = (ev.iteration, ctx.current_time_ns)
@@ -351,9 +250,8 @@ end
 # `span_id` to compute and log the iteration's wall-clock duration.
 function log_event(ctx::LogContext, ev::AfterIterationEvent, _idx)
     _log_text!(
-        ctx,
-        "after_iteration",
-        "model: $(ev.model) | iteration: $(ev.iteration) | stop_iteration: $(ev.stop_iteration) | span_id: $(ev.span_id)";
+        ctx, "after_iteration",
+        _format_fields(ev, (:model, :iteration, :stop_iteration, :span_id));
         step = ev.iteration,
     )
     if haskey(ctx.before_times, ev.span_id)
@@ -368,18 +266,16 @@ end
 
 function log_event(ctx::LogContext, ev::BeforeDataUpdateEvent, idx)
     _log_text!(
-        ctx,
-        "before_data_update",
-        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
+        ctx, "before_data_update",
+        _format_fields(ev, (:model, :data, :span_id));
         step = idx,
     )
 end
 
 function log_event(ctx::LogContext, ev::AfterDataUpdateEvent, idx)
     _log_text!(
-        ctx,
-        "after_data_update",
-        "model: $(ev.model) | data: $(ev.data) | span_id: $(ev.span_id)";
+        ctx, "after_data_update",
+        _format_fields(ev, (:model, :data, :span_id));
         step = idx,
     )
 end
@@ -425,18 +321,16 @@ end
 
 function log_event(ctx::LogContext, ev::BeforeAutostartEvent, idx)
     _log_text!(
-        ctx,
-        "before_autostart",
-        "engine: $(ev.engine) | span_id: $(ev.span_id)";
+        ctx, "before_autostart",
+        _format_fields(ev, (:engine, :span_id));
         step = idx,
     )
 end
 
 function log_event(ctx::LogContext, ev::AfterAutostartEvent, idx)
     _log_text!(
-        ctx,
-        "after_autostart",
-        "engine: $(ev.engine) | span_id: $(ev.span_id)";
+        ctx, "after_autostart",
+        _format_fields(ev, (:engine, :span_id));
         step = idx,
     )
 end
@@ -445,9 +339,8 @@ function log_event(
     ctx::LogContext, ev::ReactiveMP.BeforeMessageRuleCallEvent, idx
 )
     _log_text!(
-        ctx,
-        "before_message_rule_call",
-        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | span_id: $(ev.span_id)";
+        ctx, "before_message_rule_call",
+        _format_fields(ev, (:mapping, :messages, :marginals, :span_id));
         step = idx,
     )
 end
@@ -456,9 +349,11 @@ function log_event(
     ctx::LogContext, ev::ReactiveMP.AfterMessageRuleCallEvent, idx
 )
     _log_text!(
-        ctx,
-        "after_message_rule_call",
-        "mapping: $(ev.mapping) | messages: $(ev.messages) | marginals: $(ev.marginals) | result: $(ev.result) | annotations: $(ev.annotations) | span_id: $(ev.span_id)";
+        ctx, "after_message_rule_call",
+        _format_fields(
+            ev,
+            (:mapping, :messages, :marginals, :result, :annotations, :span_id),
+        );
         step = idx,
     )
 end
@@ -554,8 +449,7 @@ end
 # Fallback for unknown event types
 function log_event(ctx::LogContext, ev::ReactiveMP.Event, idx)
     _log_text!(
-        ctx,
-        "unknown_events",
+        ctx, "unknown_events",
         "event_type: $(event_name(typeof(ev)))";
         step = idx,
     )

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -591,7 +591,7 @@ end
         # Stage 2 — append Binomial predictive scalars in the same run dir.
         n_trials = 20
         logger   = TBLogger(run_dir, tb_append)
-        ctx      = ext.LogContext(logger; log_distributions = false, log_text_events   = false, n_samples         = 0)
+        ctx      = ext.LogContext(logger; log_distributions = false, log_text_events = false, n_samples = 0)
         for θ_post in results.posteriors[:θ]
             ext._log_posterior_scalars!(
                 ctx, Binomial(n_trials, mean(θ_post)), :y_pred
@@ -1180,16 +1180,16 @@ end
 
         # Every posterior tag is suppressed, including the histogram path
         # that `log_distributions=true` would otherwise enable.
-        @test !("posteriors/μ/mean"         in all_tags)
-        @test !("posteriors/μ/precision"    in all_tags)
+        @test !("posteriors/μ/mean" in all_tags)
+        @test !("posteriors/μ/precision" in all_tags)
         @test !("posteriors/μ/distribution" in all_tags)
-        @test !("posteriors/τ/shape"        in all_tags)
-        @test !("posteriors/τ/rate"         in all_tags)
+        @test !("posteriors/τ/shape" in all_tags)
+        @test !("posteriors/τ/rate" in all_tags)
         @test !("posteriors/τ/distribution" in all_tags)
 
         # Non-posterior outputs are unaffected.
         @test "iteration_time_ms" in all_tags
-        @test "EventCounts"       in all_tags
+        @test "EventCounts" in all_tags
     end
 end
 
@@ -1237,10 +1237,10 @@ end
         )
         all_tags = read_tags(run_dir)
 
-        @test "posteriors/μ/mean"      in all_tags
+        @test "posteriors/μ/mean" in all_tags
         @test "posteriors/μ/precision" in all_tags
-        @test "posteriors/τ/shape"     in all_tags
-        @test "posteriors/τ/rate"      in all_tags
+        @test "posteriors/τ/shape" in all_tags
+        @test "posteriors/τ/rate" in all_tags
 
         @test length(steps_for_tag(run_dir, "posteriors/μ/mean")) ==
             n_iterations
@@ -1298,11 +1298,11 @@ end
         )
         all_tags = read_tags(run_dir)
 
-        @test "posteriors/μ/mean"         in all_tags
-        @test "posteriors/μ/precision"    in all_tags
+        @test "posteriors/μ/mean" in all_tags
+        @test "posteriors/μ/precision" in all_tags
         @test "posteriors/μ/distribution" in all_tags
-        @test !("posteriors/τ/shape"        in all_tags)
-        @test !("posteriors/τ/rate"         in all_tags)
+        @test !("posteriors/τ/shape" in all_tags)
+        @test !("posteriors/τ/rate" in all_tags)
         @test !("posteriors/τ/distribution" in all_tags)
 
         @test length(steps_for_tag(run_dir, "posteriors/μ/mean")) ==
@@ -1319,10 +1319,10 @@ end
         )
         all_tags = read_tags(run_dir)
 
-        @test "posteriors/μ/mean"      in all_tags
+        @test "posteriors/μ/mean" in all_tags
         @test "posteriors/μ/precision" in all_tags
         @test !("posteriors/τ/shape" in all_tags)
-        @test !("posteriors/τ/rate"  in all_tags)
+        @test !("posteriors/τ/rate" in all_tags)
     end
 
     # Empty allow-list is the moral equivalent of `false`: nothing logged.
@@ -1334,7 +1334,7 @@ end
             verbose        = false,
         )
         all_tags = read_tags(run_dir)
-        @test !("posteriors/μ/mean"  in all_tags)
+        @test !("posteriors/μ/mean" in all_tags)
         @test !("posteriors/τ/shape" in all_tags)
         @test "iteration_time_ms" in all_tags
     end

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -783,6 +783,49 @@ end
     end
 end
 
+@testitem "Erlang posterior emits shape/scale scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Erlang
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Erlang is the integer-shape special case of Gamma. ReactiveMP's
+    # native rules emit `Distributions.Gamma` (matching the
+    # `GammaDistributionsFamily` union from ExponentialFamily), not
+    # Erlang — so an Erlang marginal arrives only via projection or a
+    # custom factor. Drive the dispatch helper directly via the loaded
+    # extension module.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Erlang(3, 2.0), :t)
+        ext._log_posterior_scalars!(ctx, Erlang(5, 1.5), :t)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/t/shape" in all_tags
+        @test "posteriors/t/scale" in all_tags
+
+        # Specific Erlang dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/t/mean" in all_tags)
+        @test !("posteriors/t/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/t/shape")) == 2
+        @test length(steps_for_tag(log_dir, "posteriors/t/scale")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -173,6 +173,101 @@ end
     end
 end
 
+@testitem "Beta posterior emits alpha/beta/mean scalar tags" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Beta–Bernoulli coin toss. θ has a Beta posterior; the conjugate update
+    # produces α/β scalars per iteration.
+    @model function coin_toss(y)
+        θ ~ Beta(1.0, 1.0)
+        y .~ Bernoulli(θ)
+    end
+
+    initialization = @initialization begin
+        q(θ) = vague(Beta)
+    end
+
+    dataset = rand(StableRNG(42), Bernoulli(0.7), 25)
+
+    n_iterations = 4
+    results = infer(;
+        model          = coin_toss(),
+        data           = (y = dataset,),
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
+
+        all_tags = read_tags(run_dir)
+
+        # θ is Beta → should produce alpha, beta, and mean scalar tags.
+        @test "posteriors/θ/alpha" in all_tags
+        @test "posteriors/θ/beta" in all_tags
+        @test "posteriors/θ/mean" in all_tags
+
+        # One step per iteration on the canonical α tag.
+        @test length(steps_for_tag(run_dir, "posteriors/θ/alpha")) ==
+            n_iterations
+    end
+end
+
+@testitem "Beta posterior distribution logged as HistogramSummary" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # With `log_distributions = true`, the Beta posterior must produce a
+    # per-iteration HistogramSummary alongside the α/β scalar tags.
+    @model function coin_toss(y)
+        θ ~ Beta(1.0, 1.0)
+        y .~ Bernoulli(θ)
+    end
+
+    initialization = @initialization begin
+        q(θ) = vague(Beta)
+    end
+
+    dataset = rand(StableRNG(42), Bernoulli(0.7), 25)
+
+    n_iterations = 3
+    results = infer(;
+        model          = coin_toss(),
+        data           = (y = dataset,),
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file = log_dir,
+            log_distributions = true,
+            n_samples = 256,
+            verbose = false,
+        )
+
+        all_tags = read_tags(run_dir)
+
+        @test "posteriors/θ/distribution" in all_tags
+        @test length(steps_for_tag(run_dir, "posteriors/θ/distribution")) ==
+            n_iterations
+
+        # Scalars must still coexist with the histogram tag.
+        @test "posteriors/θ/alpha" in all_tags
+        @test "posteriors/θ/beta" in all_tags
+    end
+end
+
 @testitem "Default trace export does not emit distribution tags" begin
     using RxInfer, StableRNGs, TensorBoardLogger
     include(joinpath(@__DIR__, "helpers.jl"))

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -908,6 +908,46 @@ end
     end
 end
 
+@testitem "Rayleigh posterior emits scale scalar tag" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Rayleigh
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # InverseGamma is conjugate to Rayleigh on σ² — the posterior over
+    # the squared scale is InverseGamma, not Rayleigh. ReactiveMP has
+    # no native Rayleigh rules or graph node, so a Rayleigh marginal
+    # arrives only via custom factors or projection. Drive the dispatch
+    # helper directly.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Rayleigh(1.0), :r)
+        ext._log_posterior_scalars!(ctx, Rayleigh(2.0), :r)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/r/scale" in all_tags
+
+        # Specific Rayleigh dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/r/mean" in all_tags)
+        @test !("posteriors/r/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/r/scale")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -866,6 +866,48 @@ end
     end
 end
 
+@testitem "Pareto posterior emits shape/scale scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Pareto
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Gamma is conjugate to Pareto on the *shape* parameter — the
+    # posterior over the Pareto shape is Gamma, not Pareto. ReactiveMP
+    # has no native Pareto rules or graph node, so a Pareto marginal
+    # arrives only via custom factors or projection. Drive the dispatch
+    # helper directly.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Pareto(2.5, 1.0), :x)
+        ext._log_posterior_scalars!(ctx, Pareto(3.0, 1.5), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/shape" in all_tags
+        @test "posteriors/x/scale" in all_tags
+
+        # Specific Pareto dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/x/mean" in all_tags)
+        @test !("posteriors/x/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/x/shape")) == 2
+        @test length(steps_for_tag(log_dir, "posteriors/x/scale")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -743,6 +743,46 @@ end
     end
 end
 
+@testitem "LogNormal posterior emits meanlog/stdlog scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: LogNormal
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native LogNormal message rules and no LogNormal
+    # graph node, so a LogNormal posterior would only ever arrive via a
+    # custom factor or projection. Drive the dispatch helper directly.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, LogNormal(0.0, 1.0), :x)
+        ext._log_posterior_scalars!(ctx, LogNormal(0.5, 0.7), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/meanlog" in all_tags
+        @test "posteriors/x/stdlog"  in all_tags
+
+        # Specific LogNormal dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/x/mean" in all_tags)
+        @test !("posteriors/x/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/x/meanlog")) == 2
+        @test length(steps_for_tag(log_dir, "posteriors/x/stdlog"))  == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -702,6 +702,47 @@ end
     end
 end
 
+@testitem "Weibull posterior emits shape/scale scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Weibull
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native Weibull message rules and no Weibull
+    # graph node, so a Weibull posterior would only ever arrive via a
+    # custom factor or projection. Drive the dispatch helper directly via
+    # the loaded extension module.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Weibull(1.5, 2.0), :t)
+        ext._log_posterior_scalars!(ctx, Weibull(2.5, 1.2), :t)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/t/shape" in all_tags
+        @test "posteriors/t/scale" in all_tags
+
+        # Specific Weibull dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/t/mean" in all_tags)
+        @test !("posteriors/t/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/t/shape")) == 2
+        @test length(steps_for_tag(log_dir, "posteriors/t/scale")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -276,7 +276,7 @@ end
     # its posterior arrives as `InverseGamma` (alias of `Distributions.InverseGamma`).
     @model function iid_invgamma(y)
         μ  ~ Normal(mean = 0.0, variance = 100.0)
-        σ² ~ GammaInverse(shape = 2.0, scale = 1.0)
+        σ² ~ GammaInverse(α = 2.0, θ = 1.0)
         y .~ Normal(mean = μ, variance = σ²)
     end
 
@@ -330,7 +330,7 @@ end
 
     @model function iid_invgamma(y)
         μ  ~ Normal(mean = 0.0, variance = 100.0)
-        σ² ~ GammaInverse(shape = 2.0, scale = 1.0)
+        σ² ~ GammaInverse(α = 2.0, θ = 1.0)
         y .~ Normal(mean = μ, variance = σ²)
     end
 

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -660,6 +660,48 @@ end
     end
 end
 
+@testitem "VonMises posterior emits location/concentration scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: VonMises
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native VonMises message rules and no VonMises
+    # graph node, so a VonMises posterior would only ever arrive via a
+    # custom factor or projection. Drive the dispatch helper directly via
+    # the loaded extension module — same pattern as Geometric and the
+    # other no-rule distributions.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, VonMises(0.0, 2.0), :θ)
+        ext._log_posterior_scalars!(ctx, VonMises(0.5, 5.0), :θ)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/θ/location"      in all_tags
+        @test "posteriors/θ/concentration" in all_tags
+
+        # Specific VonMises dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/θ/mean" in all_tags)
+        @test !("posteriors/θ/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/θ/location"))      == 2
+        @test length(steps_for_tag(log_dir, "posteriors/θ/concentration")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -419,6 +419,45 @@ end
     end
 end
 
+@testitem "Geometric posterior emits succprob scalar tag" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Geometric
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native Geometric message rules, so a Geometric
+    # posterior would only ever arrive via a custom factor or projection.
+    # Drive the dispatch helper directly via the loaded extension module —
+    # same pattern as the Poisson and generic-fallback tests.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Geometric(0.3), :k)
+        ext._log_posterior_scalars!(ctx, Geometric(0.6), :k)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/k/succprob" in all_tags
+
+        # Specific Geometric dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/k/mean" in all_tags)
+        @test !("posteriors/k/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Exponential

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -826,6 +826,46 @@ end
     end
 end
 
+@testitem "Laplace posterior emits location/scale scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Laplace
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native Laplace message rules and no Laplace
+    # graph node, so a Laplace posterior would only ever arrive via a
+    # custom factor or projection. Drive the dispatch helper directly.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Laplace(0.0, 1.0), :x)
+        ext._log_posterior_scalars!(ctx, Laplace(0.5, 0.7), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/location" in all_tags
+        @test "posteriors/x/scale"    in all_tags
+
+        # Specific Laplace dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/x/mean" in all_tags)
+        @test !("posteriors/x/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/x/location")) == 2
+        @test length(steps_for_tag(log_dir, "posteriors/x/scale"))    == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -500,6 +500,127 @@ end
     end
 end
 
+@testitem "Binomial posterior emits ntrials/succprob scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Binomial
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Beta is conjugate to Binomial on the success probability — the posterior
+    # over θ is Beta, not Binomial. A Binomial marginal therefore arrives only
+    # via projection or as a predictive child. Drive the dispatch helper
+    # directly via the loaded extension module.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Binomial(10, 0.4), :k)
+        ext._log_posterior_scalars!(ctx, Binomial(20, 0.6), :k)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/k/ntrials"  in all_tags
+        @test "posteriors/k/succprob" in all_tags
+
+        # Specific Binomial dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/k/mean" in all_tags)
+        @test !("posteriors/k/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/k/ntrials"))  == 2
+        @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
+    end
+end
+
+@testitem "Beta-Binomial conjugate workflow emits Binomial predictive tags" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    using Distributions: Binomial
+    using Statistics: mean
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # End-to-end Beta–Binomial: run real RxInfer inference under a Beta
+    # prior + Bernoulli likelihood (RxInfer has native rules for those),
+    # then turn each iteration's Beta posterior over θ into a Binomial
+    # predictive over a count of n_trials future flips and log it via the
+    # new Binomial dispatch. This locks in the workflow the dev script in
+    # `src/tensorboard_binomial_beta.jl` demonstrates.
+    @model function coin_toss(y)
+        θ ~ Beta(1.0, 1.0)
+        y .~ Bernoulli(θ)
+    end
+
+    initialization = @initialization begin
+        q(θ) = vague(Beta)
+    end
+
+    dataset = rand(StableRNG(42), Bernoulli(0.7), 25)
+
+    n_iterations = 4
+    results = infer(;
+        model          = coin_toss(),
+        data           = (y = dataset,),
+        iterations     = n_iterations,
+        initialization = initialization,
+        returnvars     = (θ = KeepEach(),),
+        trace          = true,
+    )
+
+    @test length(results.posteriors[:θ]) == n_iterations
+
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        # Stage 1 — standard trace export to populate the Beta scalars.
+        run_dir = RxInfer.convert_to_tensorboard(
+            results.model.metadata[:trace];
+            output_file       = log_dir,
+            log_distributions = false,
+            verbose           = false,
+        )
+
+        # Stage 2 — append Binomial predictive scalars in the same run dir.
+        n_trials = 20
+        logger   = TBLogger(run_dir, tb_append)
+        ctx      = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+        for θ_post in results.posteriors[:θ]
+            ext._log_posterior_scalars!(
+                ctx, Binomial(n_trials, mean(θ_post)), :y_pred
+            )
+        end
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(run_dir)
+
+        # Beta posterior tags from stage 1.
+        @test "posteriors/θ/alpha"   in all_tags
+        @test "posteriors/θ/beta"    in all_tags
+
+        # Binomial predictive tags from stage 2.
+        @test "posteriors/y_pred/ntrials"  in all_tags
+        @test "posteriors/y_pred/succprob" in all_tags
+
+        @test length(steps_for_tag(run_dir, "posteriors/y_pred/ntrials")) ==
+            n_iterations
+    end
+end
+
 @testitem "Exponential posterior emits rate scalar tag" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Exponential

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -376,6 +376,49 @@ end
     end
 end
 
+@testitem "Poisson posterior emits rate scalar tag" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Poisson
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Poisson posteriors arrive in RxInfer as predictive marginals on
+    # unobserved Poisson children (see ReactiveMP `@rule Poisson(:out, ...)`
+    # under a Gamma rate). Engineering a full predictive model just to
+    # exercise the scalar dispatch would be model-specific churn, so we call
+    # the dispatch helper directly via the loaded extension module — same
+    # pattern as the generic-fallback test below.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        # Two updates so we can lock in the per-variable step counter
+        # behaviour the existing scalars rely on.
+        ext._log_posterior_scalars!(ctx, Poisson(3.0), :n)
+        ext._log_posterior_scalars!(ctx, Poisson(4.5), :n)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/n/rate" in all_tags
+
+        # Specific Poisson dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/n/mean" in all_tags)
+        @test !("posteriors/n/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/n/rate")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Exponential

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -458,6 +458,48 @@ end
     end
 end
 
+@testitem "NegativeBinomial posterior emits r/succprob scalar tags" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: NegativeBinomial
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # ReactiveMP has no native NegativeBinomial message rules, so a
+    # NegativeBinomial posterior would only ever arrive via a custom
+    # factor or projection. Drive the dispatch helper directly via the
+    # loaded extension module — same pattern as the Poisson, Geometric,
+    # and generic-fallback tests.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, NegativeBinomial(5.0, 0.4), :k)
+        ext._log_posterior_scalars!(ctx, NegativeBinomial(7.0, 0.6), :k)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/k/r"        in all_tags
+        @test "posteriors/k/succprob" in all_tags
+
+        # Specific NegativeBinomial dispatch must beat the generic fallback.
+        @test !("posteriors/k/mean" in all_tags)
+        @test !("posteriors/k/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/k/r"))        == 2
+        @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Exponential

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -948,6 +948,45 @@ end
     end
 end
 
+@testitem "Chisq posterior emits dof scalar tag" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Chisq
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Chisq is a Gamma special case (shape = ν/2, scale = 2). ReactiveMP's
+    # Gamma rules emit `Distributions.Gamma`, not Chisq, so a Chisq
+    # marginal arrives only via custom factors or projection. Drive the
+    # dispatch helper directly via the loaded extension module.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Chisq(3.0), :x)
+        ext._log_posterior_scalars!(ctx, Chisq(7.0), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/dof" in all_tags
+
+        # Specific Chisq dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/x/mean" in all_tags)
+        @test !("posteriors/x/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/x/dof")) == 2
+    end
+end
+
 @testitem "Generic UnivariateDistribution fallback emits mean/var" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Uniform

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -275,7 +275,7 @@ end
     # Normal–InverseGamma model: σ² is variance with a GammaInverse prior, so
     # its posterior arrives as `InverseGamma` (alias of `Distributions.InverseGamma`).
     @model function iid_invgamma(y)
-        μ  ~ Normal(mean = 0.0, variance = 100.0)
+        μ ~ Normal(mean = 0.0, variance = 100.0)
         σ² ~ GammaInverse(α = 2.0, θ = 1.0)
         y .~ Normal(mean = μ, variance = σ²)
     end
@@ -285,7 +285,7 @@ end
     end
 
     initialization = @initialization begin
-        q(μ)  = vague(NormalMeanVariance)
+        q(μ) = vague(NormalMeanVariance)
         q(σ²) = vague(GammaInverse)
     end
 
@@ -329,7 +329,7 @@ end
     include(joinpath(@__DIR__, "helpers.jl"))
 
     @model function iid_invgamma(y)
-        μ  ~ Normal(mean = 0.0, variance = 100.0)
+        μ ~ Normal(mean = 0.0, variance = 100.0)
         σ² ~ GammaInverse(α = 2.0, θ = 1.0)
         y .~ Normal(mean = μ, variance = σ²)
     end
@@ -339,7 +339,7 @@ end
     end
 
     initialization = @initialization begin
-        q(μ)  = vague(NormalMeanVariance)
+        q(μ) = vague(NormalMeanVariance)
         q(σ²) = vague(GammaInverse)
     end
 
@@ -413,7 +413,7 @@ end
 
         # Specific Poisson dispatch must beat the generic mean/var fallback.
         @test !("posteriors/n/mean" in all_tags)
-        @test !("posteriors/n/var"  in all_tags)
+        @test !("posteriors/n/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/n/rate")) == 2
     end
@@ -452,7 +452,7 @@ end
 
         # Specific Geometric dispatch must beat the generic mean/var fallback.
         @test !("posteriors/k/mean" in all_tags)
-        @test !("posteriors/k/var"  in all_tags)
+        @test !("posteriors/k/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
     end
@@ -488,14 +488,14 @@ end
         GC.gc()
 
         all_tags = read_tags(log_dir)
-        @test "posteriors/k/r"        in all_tags
+        @test "posteriors/k/r" in all_tags
         @test "posteriors/k/succprob" in all_tags
 
         # Specific NegativeBinomial dispatch must beat the generic fallback.
         @test !("posteriors/k/mean" in all_tags)
-        @test !("posteriors/k/var"  in all_tags)
+        @test !("posteriors/k/var" in all_tags)
 
-        @test length(steps_for_tag(log_dir, "posteriors/k/r"))        == 2
+        @test length(steps_for_tag(log_dir, "posteriors/k/r")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
     end
 end
@@ -529,14 +529,14 @@ end
         GC.gc()
 
         all_tags = read_tags(log_dir)
-        @test "posteriors/k/ntrials"  in all_tags
+        @test "posteriors/k/ntrials" in all_tags
         @test "posteriors/k/succprob" in all_tags
 
         # Specific Binomial dispatch must beat the generic mean/var fallback.
         @test !("posteriors/k/mean" in all_tags)
-        @test !("posteriors/k/var"  in all_tags)
+        @test !("posteriors/k/var" in all_tags)
 
-        @test length(steps_for_tag(log_dir, "posteriors/k/ntrials"))  == 2
+        @test length(steps_for_tag(log_dir, "posteriors/k/ntrials")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/k/succprob")) == 2
     end
 end
@@ -591,12 +591,7 @@ end
         # Stage 2 — append Binomial predictive scalars in the same run dir.
         n_trials = 20
         logger   = TBLogger(run_dir, tb_append)
-        ctx      = ext.LogContext(
-            logger;
-            log_distributions = false,
-            log_text_events   = false,
-            n_samples         = 0,
-        )
+        ctx      = ext.LogContext(logger; log_distributions = false, log_text_events   = false, n_samples         = 0)
         for θ_post in results.posteriors[:θ]
             ext._log_posterior_scalars!(
                 ctx, Binomial(n_trials, mean(θ_post)), :y_pred
@@ -609,11 +604,11 @@ end
         all_tags = read_tags(run_dir)
 
         # Beta posterior tags from stage 1.
-        @test "posteriors/θ/alpha"   in all_tags
-        @test "posteriors/θ/beta"    in all_tags
+        @test "posteriors/θ/alpha" in all_tags
+        @test "posteriors/θ/beta" in all_tags
 
         # Binomial predictive tags from stage 2.
-        @test "posteriors/y_pred/ntrials"  in all_tags
+        @test "posteriors/y_pred/ntrials" in all_tags
         @test "posteriors/y_pred/succprob" in all_tags
 
         @test length(steps_for_tag(run_dir, "posteriors/y_pred/ntrials")) ==
@@ -654,7 +649,7 @@ end
 
         # Specific Exponential dispatch must beat the generic mean/var fallback.
         @test !("posteriors/x/mean" in all_tags)
-        @test !("posteriors/x/var"  in all_tags)
+        @test !("posteriors/x/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/x/rate")) == 2
     end
@@ -690,14 +685,14 @@ end
         GC.gc()
 
         all_tags = read_tags(log_dir)
-        @test "posteriors/θ/location"      in all_tags
+        @test "posteriors/θ/location" in all_tags
         @test "posteriors/θ/concentration" in all_tags
 
         # Specific VonMises dispatch must beat the generic mean/var fallback.
         @test !("posteriors/θ/mean" in all_tags)
-        @test !("posteriors/θ/var"  in all_tags)
+        @test !("posteriors/θ/var" in all_tags)
 
-        @test length(steps_for_tag(log_dir, "posteriors/θ/location"))      == 2
+        @test length(steps_for_tag(log_dir, "posteriors/θ/location")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/θ/concentration")) == 2
     end
 end
@@ -736,7 +731,7 @@ end
 
         # Specific Weibull dispatch must beat the generic mean/var fallback.
         @test !("posteriors/t/mean" in all_tags)
-        @test !("posteriors/t/var"  in all_tags)
+        @test !("posteriors/t/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/t/shape")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/t/scale")) == 2
@@ -772,14 +767,14 @@ end
 
         all_tags = read_tags(log_dir)
         @test "posteriors/x/meanlog" in all_tags
-        @test "posteriors/x/stdlog"  in all_tags
+        @test "posteriors/x/stdlog" in all_tags
 
         # Specific LogNormal dispatch must beat the generic mean/var fallback.
         @test !("posteriors/x/mean" in all_tags)
-        @test !("posteriors/x/var"  in all_tags)
+        @test !("posteriors/x/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/x/meanlog")) == 2
-        @test length(steps_for_tag(log_dir, "posteriors/x/stdlog"))  == 2
+        @test length(steps_for_tag(log_dir, "posteriors/x/stdlog")) == 2
     end
 end
 
@@ -819,7 +814,7 @@ end
 
         # Specific Erlang dispatch must beat the generic mean/var fallback.
         @test !("posteriors/t/mean" in all_tags)
-        @test !("posteriors/t/var"  in all_tags)
+        @test !("posteriors/t/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/t/shape")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/t/scale")) == 2
@@ -855,14 +850,14 @@ end
 
         all_tags = read_tags(log_dir)
         @test "posteriors/x/location" in all_tags
-        @test "posteriors/x/scale"    in all_tags
+        @test "posteriors/x/scale" in all_tags
 
         # Specific Laplace dispatch must beat the generic mean/var fallback.
         @test !("posteriors/x/mean" in all_tags)
-        @test !("posteriors/x/var"  in all_tags)
+        @test !("posteriors/x/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/x/location")) == 2
-        @test length(steps_for_tag(log_dir, "posteriors/x/scale"))    == 2
+        @test length(steps_for_tag(log_dir, "posteriors/x/scale")) == 2
     end
 end
 
@@ -901,7 +896,7 @@ end
 
         # Specific Pareto dispatch must beat the generic mean/var fallback.
         @test !("posteriors/x/mean" in all_tags)
-        @test !("posteriors/x/var"  in all_tags)
+        @test !("posteriors/x/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/x/shape")) == 2
         @test length(steps_for_tag(log_dir, "posteriors/x/scale")) == 2
@@ -942,7 +937,7 @@ end
 
         # Specific Rayleigh dispatch must beat the generic mean/var fallback.
         @test !("posteriors/r/mean" in all_tags)
-        @test !("posteriors/r/var"  in all_tags)
+        @test !("posteriors/r/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/r/scale")) == 2
     end
@@ -981,7 +976,7 @@ end
 
         # Specific Chisq dispatch must beat the generic mean/var fallback.
         @test !("posteriors/x/mean" in all_tags)
-        @test !("posteriors/x/var"  in all_tags)
+        @test !("posteriors/x/var" in all_tags)
 
         @test length(steps_for_tag(log_dir, "posteriors/x/dof")) == 2
     end
@@ -1019,7 +1014,7 @@ end
 
         all_tags = read_tags(log_dir)
         @test "posteriors/x/mean" in all_tags
-        @test "posteriors/x/var"  in all_tags
+        @test "posteriors/x/var" in all_tags
     end
 end
 

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -500,12 +500,51 @@ end
     end
 end
 
-@testitem "Generic UnivariateDistribution fallback emits mean/var" begin
+@testitem "Exponential posterior emits rate scalar tag" begin
     using RxInfer, TensorBoardLogger
     using Distributions: Exponential
     include(joinpath(@__DIR__, "helpers.jl"))
 
-    # No special-case dispatch exists for `Exponential`, so it should fall
+    # Exponential is conjugate-on-rate to Gamma — the posterior over a rate
+    # parameter is Gamma, not Exponential. An Exponential marginal therefore
+    # arrives only via projection or as a predictive child of a Gamma rate.
+    # Drive the dispatch helper directly via the loaded extension module.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        ext._log_posterior_scalars!(ctx, Exponential(2.0), :x)
+        ext._log_posterior_scalars!(ctx, Exponential(0.5), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/rate" in all_tags
+
+        # Specific Exponential dispatch must beat the generic mean/var fallback.
+        @test !("posteriors/x/mean" in all_tags)
+        @test !("posteriors/x/var"  in all_tags)
+
+        @test length(steps_for_tag(log_dir, "posteriors/x/rate")) == 2
+    end
+end
+
+@testitem "Generic UnivariateDistribution fallback emits mean/var" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Uniform
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # No special-case dispatch exists for `Uniform`, so it should fall
     # through to the generic UnivariateDistribution method emitting `mean`
     # and `var`. Reach into the loaded extension module to call the helper
     # directly — engineering a model whose ReactiveMP posterior arrives as
@@ -522,9 +561,9 @@ end
             n_samples         = 0,
         )
 
-        # Exponential(λ=2.0) — no specific dispatch; falls through to
-        # the generic UnivariateDistribution method.
-        ext._log_posterior_scalars!(ctx, Exponential(2.0), :x)
+        # Uniform(0, 1) — no specific dispatch; falls through to the
+        # generic UnivariateDistribution method.
+        ext._log_posterior_scalars!(ctx, Uniform(0.0, 1.0), :x)
 
         close(logger)
         empty!(logger.all_files)

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -268,6 +268,150 @@ end
     end
 end
 
+@testitem "InverseGamma posterior emits shape/scale scalar tags" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Normal–InverseGamma model: σ² is variance with a GammaInverse prior, so
+    # its posterior arrives as `InverseGamma` (alias of `Distributions.InverseGamma`).
+    @model function iid_invgamma(y)
+        μ  ~ Normal(mean = 0.0, variance = 100.0)
+        σ² ~ GammaInverse(shape = 2.0, scale = 1.0)
+        y .~ Normal(mean = μ, variance = σ²)
+    end
+
+    constraints = @constraints begin
+        q(μ, σ²) = q(μ)q(σ²)
+    end
+
+    initialization = @initialization begin
+        q(μ)  = vague(NormalMeanVariance)
+        q(σ²) = vague(GammaInverse)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanVariance(3.1415, 1.0 / 2.7182), 25)
+
+    n_iterations = 4
+    results = infer(;
+        model          = iid_invgamma(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace; output_file = log_dir, verbose = false
+        )
+
+        all_tags = read_tags(run_dir)
+
+        # σ² is InverseGamma → shape and scale scalar tags.
+        @test "posteriors/σ²/shape" in all_tags
+        @test "posteriors/σ²/scale" in all_tags
+
+        # μ stays in the existing Normal family branch.
+        @test "posteriors/μ/mean" in all_tags
+        @test "posteriors/μ/precision" in all_tags
+
+        # One step per iteration on σ²/shape.
+        @test length(steps_for_tag(run_dir, "posteriors/σ²/shape")) ==
+            n_iterations
+    end
+end
+
+@testitem "InverseGamma posterior distribution logged as HistogramSummary" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    @model function iid_invgamma(y)
+        μ  ~ Normal(mean = 0.0, variance = 100.0)
+        σ² ~ GammaInverse(shape = 2.0, scale = 1.0)
+        y .~ Normal(mean = μ, variance = σ²)
+    end
+
+    constraints = @constraints begin
+        q(μ, σ²) = q(μ)q(σ²)
+    end
+
+    initialization = @initialization begin
+        q(μ)  = vague(NormalMeanVariance)
+        q(σ²) = vague(GammaInverse)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanVariance(3.1415, 1.0 / 2.7182), 25)
+
+    n_iterations = 3
+    results = infer(;
+        model          = iid_invgamma(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file = log_dir,
+            log_distributions = true,
+            n_samples = 256,
+            verbose = false,
+        )
+
+        all_tags = read_tags(run_dir)
+
+        @test "posteriors/σ²/distribution" in all_tags
+        @test length(steps_for_tag(run_dir, "posteriors/σ²/distribution")) ==
+            n_iterations
+        @test "posteriors/σ²/shape" in all_tags
+        @test "posteriors/σ²/scale" in all_tags
+    end
+end
+
+@testitem "Generic UnivariateDistribution fallback emits mean/var" begin
+    using RxInfer, TensorBoardLogger
+    using Distributions: Exponential
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # No special-case dispatch exists for `Exponential`, so it should fall
+    # through to the generic UnivariateDistribution method emitting `mean`
+    # and `var`. Reach into the loaded extension module to call the helper
+    # directly — engineering a model whose ReactiveMP posterior arrives as
+    # a non-conjugate Distributions.jl type would be model-specific churn.
+    ext = Base.get_extension(RxInfer, :TensorBoardLoggerExt)
+    @test ext !== nothing
+
+    with_safe_tempdir() do log_dir
+        logger = TBLogger(log_dir, tb_append)
+        ctx = ext.LogContext(
+            logger;
+            log_distributions = false,
+            log_text_events   = false,
+            n_samples         = 0,
+        )
+
+        # Exponential(λ=2.0) — no specific dispatch; falls through to
+        # the generic UnivariateDistribution method.
+        ext._log_posterior_scalars!(ctx, Exponential(2.0), :x)
+
+        close(logger)
+        empty!(logger.all_files)
+        GC.gc()
+
+        all_tags = read_tags(log_dir)
+        @test "posteriors/x/mean" in all_tags
+        @test "posteriors/x/var"  in all_tags
+    end
+end
+
 @testitem "Default trace export does not emit distribution tags" begin
     using RxInfer, StableRNGs, TensorBoardLogger
     include(joinpath(@__DIR__, "helpers.jl"))

--- a/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
+++ b/test/ext/TensorBoardLoggerExt/tensorboardlogger_tests.jl
@@ -1131,3 +1131,211 @@ end
         @test "posteriors/μ/mean" in all_tags
     end
 end
+
+@testitem "log_posteriors=false suppresses every posterior tag" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # `log_posteriors=false` short-circuits both the scalar and histogram
+    # paths inside `OnMarginalUpdateEvent`, so no `posteriors/*` tag should
+    # appear. Iteration timing is independent and must still flow — proves
+    # the gate is scoped to posteriors and not to the whole event loop.
+    @model function iid_estimation(y)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
+
+    results = infer(;
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = 3,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file       = log_dir,
+            log_posteriors    = false,
+            log_distributions = true,
+            verbose           = false,
+        )
+        all_tags = read_tags(run_dir)
+
+        # Every posterior tag is suppressed, including the histogram path
+        # that `log_distributions=true` would otherwise enable.
+        @test !("posteriors/μ/mean"         in all_tags)
+        @test !("posteriors/μ/precision"    in all_tags)
+        @test !("posteriors/μ/distribution" in all_tags)
+        @test !("posteriors/τ/shape"        in all_tags)
+        @test !("posteriors/τ/rate"         in all_tags)
+        @test !("posteriors/τ/distribution" in all_tags)
+
+        # Non-posterior outputs are unaffected.
+        @test "iteration_time_ms" in all_tags
+        @test "EventCounts"       in all_tags
+    end
+end
+
+@testitem "log_posteriors=true preserves default posterior logging" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # Regression guard: passing `log_posteriors=true` explicitly must
+    # produce the same posterior tags as the historical (always-on) path.
+    @model function iid_estimation(y)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
+
+    n_iterations = 4
+    results = infer(;
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file    = log_dir,
+            log_posteriors = true,
+            verbose        = false,
+        )
+        all_tags = read_tags(run_dir)
+
+        @test "posteriors/μ/mean"      in all_tags
+        @test "posteriors/μ/precision" in all_tags
+        @test "posteriors/τ/shape"     in all_tags
+        @test "posteriors/τ/rate"      in all_tags
+
+        @test length(steps_for_tag(run_dir, "posteriors/μ/mean")) ==
+            n_iterations
+        @test length(steps_for_tag(run_dir, "posteriors/τ/shape")) ==
+            n_iterations
+    end
+end
+
+@testitem "log_posteriors allow-list filters scalar and histogram paths" begin
+    using RxInfer, StableRNGs, TensorBoardLogger
+    include(joinpath(@__DIR__, "helpers.jl"))
+
+    # An allow-list of variable names must restrict logging to only the
+    # named marginals, across both the scalar and histogram paths. The
+    # excluded variable's tags must be entirely absent. We also confirm
+    # that the allow-list accepts both `String` and `Symbol` element
+    # types, which is the documented dual-input contract.
+    @model function iid_estimation(y)
+        μ ~ Normal(; mean = 0.0, precision = 0.1)
+        τ ~ Gamma(; shape = 1.0, rate = 1.0)
+        y .~ Normal(; mean = μ, precision = τ)
+    end
+
+    constraints = @constraints begin
+        q(μ, τ) = q(μ)q(τ)
+    end
+
+    initialization = @initialization begin
+        q(μ) = vague(NormalMeanPrecision)
+        q(τ) = vague(GammaShapeRate)
+    end
+
+    dataset = rand(StableRNG(42), NormalMeanPrecision(3.1415, 2.7182), 25)
+
+    n_iterations = 3
+    results = infer(;
+        model          = iid_estimation(),
+        data           = (y = dataset,),
+        constraints    = constraints,
+        iterations     = n_iterations,
+        initialization = initialization,
+        trace          = true,
+    )
+
+    trace = results.model.metadata[:trace]
+
+    # String form: log only μ. τ's scalar and histogram tags must be absent.
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file       = log_dir,
+            log_posteriors    = ["μ"],
+            log_distributions = true,
+            verbose           = false,
+        )
+        all_tags = read_tags(run_dir)
+
+        @test "posteriors/μ/mean"         in all_tags
+        @test "posteriors/μ/precision"    in all_tags
+        @test "posteriors/μ/distribution" in all_tags
+        @test !("posteriors/τ/shape"        in all_tags)
+        @test !("posteriors/τ/rate"         in all_tags)
+        @test !("posteriors/τ/distribution" in all_tags)
+
+        @test length(steps_for_tag(run_dir, "posteriors/μ/mean")) ==
+            n_iterations
+    end
+
+    # Symbol form: identical filter behavior, proving String/Symbol parity.
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file    = log_dir,
+            log_posteriors = [:μ],
+            verbose        = false,
+        )
+        all_tags = read_tags(run_dir)
+
+        @test "posteriors/μ/mean"      in all_tags
+        @test "posteriors/μ/precision" in all_tags
+        @test !("posteriors/τ/shape" in all_tags)
+        @test !("posteriors/τ/rate"  in all_tags)
+    end
+
+    # Empty allow-list is the moral equivalent of `false`: nothing logged.
+    with_safe_tempdir() do log_dir
+        run_dir = RxInfer.convert_to_tensorboard(
+            trace;
+            output_file    = log_dir,
+            log_posteriors = String[],
+            verbose        = false,
+        )
+        all_tags = read_tags(run_dir)
+        @test !("posteriors/μ/mean"  in all_tags)
+        @test !("posteriors/τ/shape" in all_tags)
+        @test "iteration_time_ms" in all_tags
+    end
+end


### PR DESCRIPTION
## Summary
- Adds scalar (and optional histogram) posterior logging for 16 univariate
  distributions in TensorBoardLoggerExt: Beta, Bernoulli, Binomial,
  InverseGamma, Poisson, Geometric, NegativeBinomial, Exponential, VonMises,
  Weibull, LogNormal, Erlang, Laplace, Pareto, Rayleigh, Chisq — each logged
  under `posteriors/<name>/<param>` with the family's natural parameterisation.
- Adds a generic `UnivariateDistribution` fallback that emits `mean`/`var`
  so any unspecialised univariate marginal still shows convergence in TB.
- Adds a `log_posteriors` kwarg on `convert_to_tensorboard` (`Bool` or
  allow-list of `Symbol`/`String` names) for per-variable opt-in.
- Docs (`trace-callbacks.md`) and `CHANGELOG.md` updated.