### PR TITLE
Fix Gemini docs search widget: new Vertex AI Search configId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Restored the "Search with Gemini" widget in the documentation. The Google Cloud project backing the previous Vertex AI Search `configId` no longer existed, so the widget silently stopped working. `docs/src/assets/chat.js` now points at a newly created Vertex AI Search (AI Applications) app, documents the full setup in a header comment (no API key lives in the repo — the data store, public access, and domain allowlist are configured in the GCP console; website data stores require an Enterprise-edition search app), and logs a `console.warn` instead of failing silently when the widget or the Google SDK fails to load. The same `configId` is shared with the RxInferExamples.jl documentation. ([#668](https://github.com/ReactiveBayes/RxInfer.jl/pull/668))
+
 ## [5.3.3] - 2026-06-01
 
 ### Changed

--- a/docs/src/assets/chat.js
+++ b/docs/src/assets/chat.js
@@ -1,10 +1,30 @@
-// In docs/src/assets/chat-widget.js
+// "Search with Gemini" widget — Google Vertex AI Search (a.k.a. Agent Search / AI Applications).
+//
+// How it works: there is NO API key in this repo. The `configId` below points to a search app
+// configured in Google Cloud Console -> AI Applications -> (app) -> Integration -> Widget tab.
+// That console page controls everything: the indexed data store (a website crawl of the
+// RxInfer docs sites), public access authorization, and the domain allowlist (docs.rxinfer.com
+// must be allowlisted there or the widget refuses to load).
+//
+// If this breaks: most likely the GCP project/app behind the configId is gone or its domain
+// allowlist changed. Re-create a "Website Content" data store + Search app in AI Applications
+// (the app MUST be Enterprise edition - website data stores require it; keep the
+// "Advanced LLM features" add-on off), grab the new configId from the Integration page,
+// and update it below.
+//
+// Current setup (June 2026): data store "rxinfer-docs-examples" (website crawl of the
+// RxInfer docs sites), Enterprise-edition search app, public access, domain allowlist
+// includes docs.rxinfer.com. Shared with the RxInferExamples.jl docs (same configId there).
 document.addEventListener('DOMContentLoaded', function() {
     // Create and append the search widget
-    const searchWidget = document.createElement('gen-search-widget');
-    searchWidget.setAttribute('configId', '1bea2ada-cbee-4d63-9154-6e68f77e8aa0');
-    searchWidget.setAttribute('triggerId', 'searchWidgetTrigger');
-    document.body.appendChild(searchWidget);
+    try {
+        const searchWidget = document.createElement('gen-search-widget');
+        searchWidget.setAttribute('configId', '25c1f1ae-0f92-4c7c-945d-5aaabdc5c7f1');
+        searchWidget.setAttribute('triggerId', 'searchWidgetTrigger');
+        document.body.appendChild(searchWidget);
+    } catch (e) {
+        console.warn('Gemini search widget failed to initialize:', e);
+    }
 
     // Find the docs search query element
     const docsSearchQuery = document.getElementById('documenter-search-query');
@@ -42,5 +62,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Load the Google Gen AI SDK
     const script = document.createElement('script');
     script.src = 'https://cloud.google.com/ai/gen-app-builder/client?hl=en_US';
+    script.onerror = function() {
+        console.warn('Gemini search widget: failed to load the Google Gen App Builder SDK');
+    };
     document.head.appendChild(script);
 });


### PR DESCRIPTION
## Summary

The \"Search with Gemini\" helper in the docs broke because the Google Cloud project backing the old Vertex AI Search `configId` no longer exists. The widget failed silently since `chat.js` had no error handling.

- Point the `<gen-search-widget>` at the newly created Vertex AI Search (AI Applications) app (`configId 25c1f1ae-0f92-4c7c-945d-5aaabdc5c7f1`)
- Document the setup in `chat.js` so the next breakage doesn't require archaeology: there is **no API key in the repo** — the data store, public access, and domain allowlist all live in GCP Console → AI Applications → Integration. Notably, website data stores require an **Enterprise-edition** search app.
- Add `try/catch` + `script.onerror` so failures surface as `console.warn` instead of vanishing

A companion PR with the same configId is opened in RxInferExamples.jl (`examples.rxinfer.com` is allowlisted on the same app).

## Test plan

- [ ] Build docs and confirm the "Search with Gemini" input appears under the native search box
- [ ] After deploy, run a query on docs.rxinfer.com and confirm the widget returns results (the freshly created index may take a few hours to fill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)