### PR TITLE
Add 'or ask DeepWiki' link under the Gemini docs search widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A small "or ask DeepWiki" link below the "Search with Gemini" widget in the documentation sidebar, pointing to the same [DeepWiki page](https://deepwiki.com/ReactiveBayes/RxInfer.jl) as the README badge. ([#670](https://github.com/ReactiveBayes/RxInfer.jl/pull/670))
+
 ## [5.3.4] - 2026-06-03
 
 ### Fixed

--- a/docs/src/assets/chat.js
+++ b/docs/src/assets/chat.js
@@ -54,9 +54,22 @@ document.addEventListener('DOMContentLoaded', function() {
         searchTrigger.classList.add('docs-search-query','input','is-rounded','is-small','is-clickable','my-2','py-1','px-2');
         
         aiSearchContainer.appendChild(searchTrigger);
-        docsSearchQuery.parentNode.insertBefore(aiSearchContainer, docsSearchQuery.nextSibling);
 
-        
+        // Add "or ask DeepWiki" link (same target as the README badge)
+        const deepWikiLink = document.createElement('div');
+        deepWikiLink.style.cssText = `
+            text-align: center;
+            font-size: 0.9em;
+        `;
+        const deepWikiAnchor = document.createElement('a');
+        deepWikiAnchor.textContent = 'or ask DeepWiki';
+        deepWikiAnchor.setAttribute('href', 'https://deepwiki.com/ReactiveBayes/RxInfer.jl');
+        deepWikiAnchor.setAttribute('target', '_blank');
+        deepWikiAnchor.setAttribute('rel', 'noopener');
+        deepWikiLink.appendChild(deepWikiAnchor);
+        aiSearchContainer.appendChild(deepWikiLink);
+
+        docsSearchQuery.parentNode.insertBefore(aiSearchContainer, docsSearchQuery.nextSibling);
     }
 
     // Load the Google Gen AI SDK

--- a/docs/src/assets/chat.js
+++ b/docs/src/assets/chat.js
@@ -59,7 +59,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const deepWikiLink = document.createElement('div');
         deepWikiLink.style.cssText = `
             text-align: center;
-            font-size: 0.9em;
+            font-size: 0.8em;
+            margin-bottom: 1rem;
         `;
         const deepWikiAnchor = document.createElement('a');
         deepWikiAnchor.textContent = 'or ask DeepWiki';


### PR DESCRIPTION
Adds a small "or ask DeepWiki" link below the "Search with Gemini" trigger input in the docs sidebar, pointing to the same DeepWiki page as the README badge (https://deepwiki.com/ReactiveBayes/RxInfer.jl). The link opens in a new tab and reuses the styling of the existing "or" separator for visual consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)