### PR TITLE
Conditioning on sparse data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for inference over **partially-referenced (sparse) conditioned data tensors**, in both batch (`infer` with `data`) and streaming (`infer` with `datastream`) modes. When a model conditions on a data array but only references some of its indices in `~` statements (e.g. masked / missing observations, or a sub-model that touches only the observed entries), GraphPPL materializes data-variable labels only at those indices, leaving the rest of the bounding box as `#undef` holes. Result collection (`getvardict`/`getvarref`), the random/data/anonymous predicates, and the per-iteration / per-tick data feed now iterate only the *assigned* entries, and the supplied dense data is fed to the materialized variables **by index** (unreferenced entries are ignored). Dense data tensors are unaffected. See the new [Partially-referenced (sparse) data](https://docs.rxinfer.com/stable/manuals/inference/partial-data/) manual page.
+
 ## [5.4.0] - 2026-06-09
 
 ### Added

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -58,6 +58,8 @@ makedocs(;
                 "Initialization" => "manuals/inference/initialization.md",
                 "Meta specification" => "manuals/inference/meta-specification.md",
                 "Auto-updates" => "manuals/inference/autoupdates.md",
+                "Partially-referenced (sparse) data" =>
+                    "manuals/inference/partial-data.md",
                 "Callbacks" => "manuals/inference/callbacks.md",
                 "Benchmark callbacks" => "manuals/inference/benchmark-callbacks.md",
                 "Trace callbacks" => "manuals/inference/trace-callbacks.md",

--- a/docs/src/manuals/inference/partial-data.md
+++ b/docs/src/manuals/inference/partial-data.md
@@ -1,0 +1,79 @@
+# [Partially-referenced (sparse) data](@id partial-data)
+
+RxInfer materializes the nodes of a conditioned data array **lazily**: a data variable is
+created only for the indices that your model actually references inside a `~` statement.
+This means you can condition on a *full, dense* data array but only wire up the entries that
+are relevant for a particular run — the unreferenced entries are simply ignored.
+
+This is useful whenever the structure of the graph depends on the data that happens to be
+available:
+
+- **Masked / missing observations** — at each time step (or for each sensor) only some
+  measurements are present, so only those should enter the likelihood.
+- **Data-driven sub-graphs** — a sub-model that branches on a mask and only connects the
+  observed indices, leaving the rest of a conditioned tensor untouched.
+- **Ragged observation sets** — a different number of observations per group, padded into a
+  rectangular array for convenience but only partially used.
+
+## Example
+
+The model below conditions on a length-3 vector `y`, but only references `y[1]` and `y[3]`.
+The value supplied at `y[2]` is never used and has no effect on the result:
+
+```julia
+using RxInfer
+
+@model function partial(y)
+    x ~ NormalMeanVariance(0.0, 100.0)
+    y[1] ~ NormalMeanVariance(x, 1.0)
+    y[3] ~ NormalMeanVariance(x, 1.0)   # y[2] is never referenced
+end
+
+# y[2] = 999.0 is provided but ignored — only y[1] and y[3] inform the posterior.
+result = infer(model = partial(), data = (y = [1.0, 999.0, 3.0],), iterations = 1)
+```
+
+The same applies to multi-dimensional tensors and to data tensors that are sliced and passed
+into sub-models, which is the typical pattern for masked, per-time-step observation blocks:
+
+```julia
+@model function observe(y_, mask_, x)
+    for j in eachindex(mask_)
+        if mask_[j]
+            y_[j] ~ NormalMeanVariance(x, 1.0)
+        end
+    end
+end
+
+@model function masked_chain(y, mask)
+    J, T = size(mask)
+    x ~ NormalMeanVariance(0.0, 100.0)
+    for t in 1:T
+        # `observe` only references the observed sensors of the t-th column of `y`.
+        x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
+    end
+end
+```
+
+## How the data is fed
+
+When a conditioned data array is only partially referenced, the corresponding array of data
+variables is **sparse** — it has the same bounding-box shape as the data, but only the
+referenced indices are materialized. During inference RxInfer feeds the provided data into
+those variables **by index**: the data variable at position `I` receives the value `data[I]`,
+and entries of `data` at unreferenced positions are ignored. You therefore pass `data` with
+its natural, dense shape — no need to pre-mask or reshape it to match the referenced subset.
+
+This applies to both batch inference (`infer` with `data`) and streaming inference (`infer`
+with `datastream`) — in the streaming case each tick's dense value is fed to the materialized
+variables by the same index alignment.
+
+## Notes and caveats
+
+- The provided `data` array must be indexable at every referenced position, i.e. its bounding
+  box must contain all the indices your model touches. Extra (unreferenced) entries are fine.
+- This applies to **data** inputs. Latent (random) variables are normally fully connected; a
+  partially-referenced latent array would leave half-edges in the graph and is not a supported
+  construction.
+- Because unreferenced indices never become part of the graph, they incur no message-passing
+  or memory cost — only the referenced sub-graph is built and run.

--- a/src/inference/batch.jl
+++ b/src/inference/batch.jl
@@ -403,7 +403,10 @@ function batch_inference(;
                 BeforeDataUpdateEvent(fmodel, data, data_update_span_id),
             )
             for (key, value) in fdata
-                new_observation!(cacheddatavars[key], get_data(value))
+                # `new_observation_indexed!` aligns by index, so a model that references a
+                # conditioned data tensor only partially (sparse data variables) is fed
+                # correctly from the dense `data` array; dense arrays behave as before.
+                new_observation_indexed!(cacheddatavars[key], get_data(value))
             end
             invoke_callback(
                 callbacks,

--- a/src/inference/streaming.jl
+++ b/src/inference/streaming.jl
@@ -382,7 +382,10 @@ function Rocket.on_next!(
                 event,
             )
             for (datavar, value) in zip(_datavars, values(event))
-                new_observation!(datavar, value)
+                # `new_observation_indexed!` aligns by index, so a model that references a
+                # streamed data tensor only partially (sparse data variables) is fed
+                # correctly from the dense streamed value; dense arrays behave as before.
+                new_observation_indexed!(datavar, value)
             end
             inference_fire_event(
                 Val(:after_data_update),

--- a/src/model/plugins/reactivemp_inference.jl
+++ b/src/model/plugins/reactivemp_inference.jl
@@ -568,8 +568,10 @@ getlabel(ref::GraphVariableRef) = ref.label
 getvariable(ref::GraphVariableRef) = ref.variable
 getname(ref::GraphVariableRef) = GraphPPL.getname(getlabel(ref))
 
+# `vec` (GraphPPL's `ResizableArray` method) yields only the *assigned* entries, so these
+# predicates are well-defined for sparse containers (a sparse data tensor is still "all data").
 GraphPPL.is_data(collection::AbstractArray{GraphVariableRef}) =
-    all(GraphPPL.is_data, collection)
+    all(GraphPPL.is_data, vec(collection))
 
 GraphPPL.is_data(ref::GraphVariableRef) = GraphPPL.is_data(ref.properties)
 GraphPPL.is_random(ref::GraphVariableRef) = GraphPPL.is_random(ref.properties)
@@ -597,10 +599,59 @@ getvarref(model::GraphPPL.Model, label::GraphPPL.NodeLabel) =
     GraphVariableRef(model, label)
 getvarref(model::GraphPPL.Model, container::AbstractArray) =
     map(element -> getvarref(model, element), container)
+getvarref(model::GraphPPL.Model, container::GraphPPL.ResizableArray) =
+    _map_sparse(element -> getvarref(model, element), container)
+
+# --- Sparse variable arrays -------------------------------------------------------------
+#
+# A `GraphPPL.ResizableArray` may be *sparse*: indexed only at some positions within its
+# bounding box, leaving the rest as `#undef` holes. This arises for data tensors that are
+# conditioned on but only *partially referenced* in the model — e.g. masked / missing
+# observations, where a sub-model only touches the observed indices and the remaining
+# entries of the conditioned array are never used. GraphPPL's `iterate`/`Base.map` over
+# such an array are deliberately dense (so `length`/`collect` stay consistent) and would
+# trip over the holes with an `UndefRefError`. The helpers below iterate only the
+# *assigned* entries instead, mirroring the sparse-aware `vec`/`isassigned` API.
+
+# Whether every index within a container's bounding box is assigned. Plain `AbstractArray`s
+# (and densely-built `ResizableArray`s) are dense; only partially-indexed `ResizableArray`s
+# are sparse. Used to keep the common dense path allocation- and behaviour-identical.
+_is_densely_assigned(::AbstractArray) = true
+_is_densely_assigned(container::GraphPPL.ResizableArray) =
+    all(I -> isassigned(container, I.I...), CartesianIndices(size(container)))
+
+# Apply `f` to a (possibly sparse) `ResizableArray`, preserving its shape. Dense arrays take
+# the fast path identical to `Base.map` (returning a plain `Array`); sparse arrays map only
+# their assigned entries into a new `ResizableArray`, leaving the holes as holes.
+function _map_sparse(f::F, container::GraphPPL.ResizableArray) where {F}
+    _is_densely_assigned(container) && return map(f, container)
+    indices = filter(I -> isassigned(container, I.I...), collect(CartesianIndices(size(container))))
+    values  = [f(container[I.I...]) for I in indices]
+    result  = GraphPPL.ResizableArray(eltype(values), Val(ndims(container)))
+    for (value, I) in zip(values, indices)
+        result[I.I...] = value
+    end
+    return result
+end
 
 getvariable(nodedata::GraphPPL.NodeData) =
     getextra(nodedata, ReactiveMPExtraVariableKey)
 getvariable(container::AbstractArray) = map(getvariable, container)
+getvariable(container::GraphPPL.ResizableArray) = _map_sparse(getvariable, container)
+
+# Feed a new observation into a (possibly sparse) array of data variables, aligning by index:
+# `datavars[I]` receives `data[I]` for every *assigned* `I`. Entries of the provided `data`
+# that the model never referenced are ignored. Dense arrays defer to `ReactiveMP` as before.
+new_observation_indexed!(datavars, data) = ReactiveMP.new_observation!(datavars, data)
+function new_observation_indexed!(datavars::GraphPPL.ResizableArray, data::AbstractArray)
+    _is_densely_assigned(datavars) && return ReactiveMP.new_observation!(datavars, data)
+    for I in CartesianIndices(size(datavars))
+        if isassigned(datavars, I.I...)
+            ReactiveMP.new_observation!(datavars[I.I...], data[I])
+        end
+    end
+    return nothing
+end
 
 function getrandomvars(model::GraphPPL.Model)
     # TODO improve performance here
@@ -644,18 +695,18 @@ obtain_marginal(ref::GraphVariableRef) =
 obtain_marginal(refs::AbstractArray) = collectLatest(map(obtain_marginal, refs))
 
 ReactiveMP.israndom(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.israndom, collection)
+    all(ReactiveMP.israndom, vec(collection))
 ReactiveMP.isdata(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.isdata, collection)
+    all(ReactiveMP.isdata, vec(collection))
 ReactiveMP.isconst(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.isconst, collection)
+    all(ReactiveMP.isconst, vec(collection))
 
 ReactiveMP.israndom(ref::GraphVariableRef) = GraphPPL.is_random(ref.properties)
 ReactiveMP.isdata(ref::GraphVariableRef) = GraphPPL.is_data(ref.properties)
 ReactiveMP.isconst(ref::GraphVariableRef) = GraphPPL.is_constant(ref.properties)
 
 isanonymous(collection::AbstractArray{GraphVariableRef}) =
-    all(isanonymous, collection)
+    all(isanonymous, vec(collection))
 isanonymous(ref::GraphVariableRef) = GraphPPL.is_anonymous(ref.properties)
 
 # Form constraint preprocessing 

--- a/test/inference/sparse_data_tests.jl
+++ b/test/inference/sparse_data_tests.jl
@@ -1,0 +1,181 @@
+# Tests for inference over *partially-referenced* (sparse) conditioned data tensors.
+#
+# When a model conditions on a data array but only references some of its indices in `~`
+# statements (e.g. masked / missing observations, or a sub-model that only touches the
+# observed entries), GraphPPL materializes data-variable labels only at those indices,
+# leaving the rest of the bounding box as `#undef` holes. Result collection
+# (`getvardict`/`getvarref`), the random/data/anonymous predicates, and the per-iteration
+# data feed must all tolerate such sparse arrays — iterating only the assigned entries —
+# and the dense data the user supplies must be fed to the materialized variables by index.
+
+@testitem "Inference with a 1-D sparse (partially-referenced) data tensor" begin
+    @model function partial_1d(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # y[2] is never referenced -> a hole
+    end
+
+    # y[2] = 999.0 is supplied but never referenced; it must be ignored entirely.
+    result = infer(model = partial_1d(), data = (y = [1.0, 999.0, 3.0],), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    # x ~ N(0, 100) with two unit-variance observations 1.0 and 3.0:
+    @test isapprox(precision(q), 1 / 100 + 2; atol = 1e-8)
+    @test isapprox(weightedmean(q), 0 / 100 + (1.0 + 3.0); atol = 1e-8)
+end
+
+@testitem "Inference with a 2-D sparse data tensor" begin
+    @model function partial_2d(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1, 1] ~ NormalMeanVariance(x, 1.0)
+        y[2, 2] ~ NormalMeanVariance(x, 1.0)
+        y[1, 3] ~ NormalMeanVariance(x, 1.0) # (2,1),(1,2),(2,3) are holes
+    end
+
+    data = reshape(collect(1.0:6.0), 2, 3) # [1 3 5; 2 4 6]
+    result = infer(model = partial_2d(), data = (y = data,), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    observed = [data[1, 1], data[2, 2], data[1, 3]] # 1.0, 4.0, 5.0
+    @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
+end
+
+@testitem "Inference with a sub-model that references data only at masked positions" begin
+    # `x` is the missing interface, so `x ~ observe(...)` binds the shared latent.
+    @model function observe(y_, mask_, x)
+        for j in eachindex(mask_)
+            if mask_[j]
+                y_[j] ~ NormalMeanVariance(x, 1.0)
+            end
+        end
+    end
+
+    @model function masked_chain(y, mask)
+        J, T = size(mask)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        for t in 1:T
+            x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
+        end
+    end
+
+    J, T = 2, 3
+    mask = Bool[1 0 1; 0 1 0] # observed: (1,1), (2,2), (1,3)
+    data = reshape(collect(1.0:6.0), J, T) # [1 3 5; 2 4 6]
+    result = infer(model = masked_chain(mask = mask), data = (y = data,), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    observed = [data[idx] for idx in findall(mask)] # 1.0, 4.0, 5.0
+    @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
+end
+
+@testitem "Dense data tensors are unaffected by the sparse-array handling" begin
+    @model function dense_model(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        for i in eachindex(y)
+            y[i] ~ NormalMeanVariance(x, 1.0)
+        end
+    end
+
+    ys = [1.0, 2.0, 3.0]
+    result = infer(model = dense_model(), data = (y = ys,), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    @test isapprox(precision(q), 1 / 100 + length(ys); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(ys); atol = 1e-8)
+end
+
+@testitem "Sparse-array helpers (_is_densely_assigned / _map_sparse)" begin
+    import RxInfer: _is_densely_assigned, _map_sparse
+    import GraphPPL: ResizableArray
+
+    # Plain arrays are always dense.
+    @test _is_densely_assigned([1, 2, 3])
+    @test _is_densely_assigned(reshape(1:6, 2, 3))
+
+    # A densely-built ResizableArray is dense; `_map_sparse` matches `Base.map` (returns Array).
+    dense = ResizableArray(Int, Val(1))
+    dense[1] = 1; dense[2] = 2; dense[3] = 3
+    @test _is_densely_assigned(dense)
+    mapped = _map_sparse(x -> x + 10, dense)
+    @test mapped isa Array
+    @test mapped == [11, 12, 13]
+
+    # A 1-D ResizableArray with a hole (use a non-bitstype so the hole is a true `#undef`).
+    sparse1 = ResizableArray(String, Val(1))
+    sparse1[1] = "a"; sparse1[3] = "c" # index 2 is a hole
+    @test !_is_densely_assigned(sparse1)
+    res1 = _map_sparse(uppercase, sparse1)
+    @test res1 isa ResizableArray
+    @test size(res1) == (3,)
+    @test isassigned(res1, 1) && !isassigned(res1, 2) && isassigned(res1, 3)
+    @test res1[1] == "A" && res1[3] == "C"
+
+    # A 2-D ResizableArray with holes preserves shape and assigned positions.
+    sparse2 = ResizableArray(String, Val(2))
+    sparse2[1, 1] = "x"; sparse2[2, 2] = "y"; sparse2[1, 3] = "z"
+    @test !_is_densely_assigned(sparse2)
+    res2 = _map_sparse(uppercase, sparse2)
+    @test res2 isa ResizableArray
+    @test res2[1, 1] == "X" && res2[2, 2] == "Y" && res2[1, 3] == "Z"
+    @test !isassigned(res2, 2, 1) && !isassigned(res2, 1, 2)
+end
+
+@testitem "Streaming inference with a partially-referenced (sparse) data tensor" begin
+    import RxInfer: from
+
+    @model function ssm_sparse(y, xm, xv)
+        x ~ NormalMeanVariance(xm, xv)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # y[2] never referenced -> hole
+    end
+
+    autoupdates = @autoupdates begin
+        xm, xv = mean_var(q(x))
+    end
+
+    run_stream(y2a, y2b) = begin
+        engine = infer(
+            model          = ssm_sparse(),
+            datastream     = from([(y = [1.0, y2a, 3.0],), (y = [2.0, y2b, 4.0],)]),
+            autoupdates    = autoupdates,
+            initialization = (@initialization begin
+                q(x) = NormalMeanVariance(0.0, 100.0)
+            end),
+            historyvars    = (x = KeepLast(),),
+            keephistory    = 10,
+            autostart      = true,
+        )
+        return engine.history[:x]
+    end
+
+    # Runs at all (previously: UndefRefError in `getvardict` before the stream started).
+    h1 = run_stream(999.0, -777.0)
+    @test length(h1) == 2
+    @test all(isfinite ∘ mean, h1)
+
+    # The unreferenced entry y[2] must have no effect on the inferred trajectory.
+    h2 = run_stream(-12345.0, 54321.0)
+    @test all(isapprox.(mean.(h1), mean.(h2); atol = 1e-10))
+    @test all(isapprox.(var.(h1), var.(h2); atol = 1e-10))
+end
+
+@testitem "new_observation_indexed! feeds sparse data variables by index" begin
+    import RxInfer: new_observation_indexed!
+    import GraphPPL: ResizableArray
+    const RMP = RxInfer.ReactiveMP
+
+    readback(dv) = RMP.getdata(RxInfer.Rocket.getrecent(dv.messageout))
+
+    # Build a sparse array of data variables with a hole at index 2.
+    vars = ResizableArray(typeof(RMP.datavar()), Val(1))
+    vars[1] = RMP.datavar()
+    vars[3] = RMP.datavar() # index 2 is a hole
+
+    # The provided dense data has 3 entries; index 2 (999.0) must be ignored.
+    new_observation_indexed!(vars, [10.0, 999.0, 30.0])
+
+    @test readback(vars[1]) == PointMass(10.0)
+    @test readback(vars[3]) == PointMass(30.0)
+end


### PR DESCRIPTION
This PR allows conditioning on dense datasets where during model construction only some indices contribute to the final graph; other entries are properly ignored. Full description below:

# [Partially-referenced (sparse) data](@id partial-data)

RxInfer materializes the nodes of a conditioned data array **lazily**: a data variable is
created only for the indices that your model actually references inside a `~` statement.
This means you can condition on a *full, dense* data array but only wire up the entries that
are relevant for a particular run — the unreferenced entries are simply ignored.

This is useful whenever the structure of the graph depends on the data that happens to be
available:

- **Masked / missing observations** — at each time step (or for each sensor) only some
  measurements are present, so only those should enter the likelihood.
- **Data-driven sub-graphs** — a sub-model that branches on a mask and only connects the
  observed indices, leaving the rest of a conditioned tensor untouched.
- **Ragged observation sets** — a different number of observations per group, padded into a
  rectangular array for convenience but only partially used.

## Example

The model below conditions on a length-3 vector `y`, but only references `y[1]` and `y[3]`.
The value supplied at `y[2]` is never used and has no effect on the result:

```julia
using RxInfer

@model function partial(y)
    x ~ NormalMeanVariance(0.0, 100.0)
    y[1] ~ NormalMeanVariance(x, 1.0)
    y[3] ~ NormalMeanVariance(x, 1.0)   # y[2] is never referenced
end

# y[2] = 999.0 is provided but ignored — only y[1] and y[3] inform the posterior.
result = infer(model = partial(), data = (y = [1.0, 999.0, 3.0],), iterations = 1)
```

The same applies to multi-dimensional tensors and to data tensors that are sliced and passed
into sub-models, which is the typical pattern for masked, per-time-step observation blocks:

```julia
@model function observe(y_, mask_, x)
    for j in eachindex(mask_)
        if mask_[j]
            y_[j] ~ NormalMeanVariance(x, 1.0)
        end
    end
end

@model function masked_chain(y, mask)
    J, T = size(mask)
    x ~ NormalMeanVariance(0.0, 100.0)
    for t in 1:T
        # `observe` only references the observed sensors of the t-th column of `y`.
        x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
    end
end
```

## How the data is fed

When a conditioned data array is only partially referenced, the corresponding array of data
variables is **sparse** — it has the same bounding-box shape as the data, but only the
referenced indices are materialized. During inference RxInfer feeds the provided data into
those variables **by index**: the data variable at position `I` receives the value `data[I]`,
and entries of `data` at unreferenced positions are ignored. You therefore pass `data` with
its natural, dense shape — no need to pre-mask or reshape it to match the referenced subset.

This applies to both batch inference (`infer` with `data`) and streaming inference (`infer`
with `datastream`) — in the streaming case each tick's dense value is fed to the materialized
variables by the same index alignment.

## Notes and caveats

- The provided `data` array must be indexable at every referenced position, i.e. its bounding
  box must contain all the indices your model touches. Extra (unreferenced) entries are fine.
- This applies to **data** inputs. Latent (random) variables are normally fully connected; a
  partially-referenced latent array would leave half-edges in the graph and is not a supported
  construction.
- Because unreferenced indices never become part of the graph, they incur no message-passing
  or memory cost — only the referenced sub-graph is built and run.