### PR TITLE
Conditioning on sparse data objects (and non-standard data-indices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for inference over **partially-referenced (sparse) conditioned data tensors**, in both batch (`infer` with `data`) and streaming (`infer` with `datastream`) modes. When a model conditions on a data array but only references some of its indices in `~` statements (e.g. masked / missing observations, or a sub-model that touches only the observed entries), GraphPPL materializes data-variable labels only at those indices, leaving the rest of the bounding box as `#undef` holes. Result collection (`getvardict`/`getvarref`), the random/data/anonymous predicates, and the per-iteration / per-tick data feed now iterate only the *assigned* entries, and the supplied dense data is fed to the materialized variables **by index** (unreferenced entries are ignored). Dense data tensors are unaffected. See the new [Partially-referenced (sparse) data](https://docs.rxinfer.com/stable/manuals/inference/partial-data/) manual page.
+
 ## [5.4.0] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for inference over **partially-referenced (sparse) conditioned data tensors**, in both batch (`infer` with `data`) and streaming (`infer` with `datastream`) modes. When a model conditions on a data array but only references some of its indices in `~` statements (e.g. masked / missing observations, or a sub-model that touches only the observed entries), GraphPPL materializes data-variable labels only at those indices, leaving the rest of the bounding box as `#undef` holes. Result collection (`getvardict`/`getvarref`), the random/data/anonymous predicates, and the per-iteration / per-tick data feed now iterate only the *assigned* entries, and the supplied dense data is fed to the materialized variables **by index** (unreferenced entries are ignored). Dense data tensors are unaffected. See the new [Partially-referenced (sparse) data](https://docs.rxinfer.com/stable/manuals/inference/partial-data/) manual page.
+- Support for conditioning on **data with non-standard (offset) indexing**, e.g. an `OffsetArray` whose axes start at `0` (or a negative index). Such data is now presented to the model with standard 1-based axes (values and order preserved), so models index it the usual way (`1:n`, `eachindex`, `axes`, …) and partial/sparse referencing works too. Standard 1-based arrays are returned unchanged with no copy. Indexing the model with a literal offset index (e.g. `y[0]`) remains unsupported.
 
 ## [5.4.0] - 2026-06-09
 

--- a/Project.toml
+++ b/Project.toml
@@ -84,6 +84,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExponentialFamilyProjection = "17f509fa-9a96-44ba-99b2-1c5f01f0931b"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
@@ -96,4 +97,4 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 
 [targets]
-test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TOML", "Coverage", "Dates", "Distributed", "Documenter", "ExponentialFamilyProjection", "Plots", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "StatsFuns", "Optimisers", "TestItemRunner", "TensorBoardLogger"]
+test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TOML", "Coverage", "Dates", "Distributed", "Documenter", "ExponentialFamilyProjection", "Plots", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "StatsFuns", "Optimisers", "TestItemRunner", "TensorBoardLogger", "OffsetArrays"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -58,6 +58,8 @@ makedocs(;
                 "Initialization" => "manuals/inference/initialization.md",
                 "Meta specification" => "manuals/inference/meta-specification.md",
                 "Auto-updates" => "manuals/inference/autoupdates.md",
+                "Partially-referenced (sparse) data" =>
+                    "manuals/inference/partial-data.md",
                 "Callbacks" => "manuals/inference/callbacks.md",
                 "Benchmark callbacks" => "manuals/inference/benchmark-callbacks.md",
                 "Trace callbacks" => "manuals/inference/trace-callbacks.md",

--- a/docs/src/manuals/inference/partial-data.md
+++ b/docs/src/manuals/inference/partial-data.md
@@ -68,6 +68,40 @@ This applies to both batch inference (`infer` with `data`) and streaming inferen
 with `datastream`) — in the streaming case each tick's dense value is fed to the materialized
 variables by the same index alignment.
 
+## Non-standard (offset) data indexing
+
+Conditioned data may use **non-standard indexing**, such as an `OffsetArray` whose axes start
+at `0` (or at a negative index). RxInfer presents such data to the model with standard 1-based
+axes — the values and their order are preserved, only the addressing is rebased. You therefore
+write your model with ordinary 1-based indexing (`1:n`, `eachindex`, `axes`, …) regardless of
+the data's native axes, and partial/sparse referencing works exactly as above:
+
+```julia
+using RxInfer, OffsetArrays
+
+@model function partial(y)
+    x ~ NormalMeanVariance(0.0, 100.0)
+    y[1] ~ NormalMeanVariance(x, 1.0)
+    y[3] ~ NormalMeanVariance(x, 1.0)
+end
+
+# A 0-based OffsetArray is accepted; the model still indexes 1-based.
+ydata  = OffsetArray([1.0, 999.0, 3.0], 0:2)
+result = infer(model = partial(), data = (y = ydata,), iterations = 1)
+```
+
+Standard (already 1-based) arrays are passed through unchanged, with no copy. Note that
+indexing the model itself with a literal offset index (e.g. writing `y[0]` inside `@model`)
+is **not** supported — variable arrays are 1-based; only the *data*'s indexing is rebased.
+
+!!! note "Rebasing incurs a copy"
+    Rebasing offset data to 1-based indexing allocates a copy of the array (once per `infer`
+    call for batch inference; once per tick for the affected variable in streaming inference).
+    A warning is emitted when this happens, gated by the `warn` keyword of [`infer`](@ref) (set
+    `warn = false` to silence it). To avoid the copy entirely, pass a 1-based array — e.g.
+    `collect(x)` or `OffsetArrays.no_offset_view(x)`. Standard 1-based data incurs no copy and no
+    warning.
+
 ## Notes and caveats
 
 - The provided `data` array must be indexable at every referenced position, i.e. its bounding

--- a/docs/src/manuals/inference/partial-data.md
+++ b/docs/src/manuals/inference/partial-data.md
@@ -1,0 +1,79 @@
+# [Partially-referenced (sparse) data](@id partial-data)
+
+RxInfer materializes the nodes of a conditioned data array **lazily**: a data variable is
+created only for the indices that your model actually references inside a `~` statement.
+This means you can condition on a *full, dense* data array but only wire up the entries that
+are relevant for a particular run — the unreferenced entries are simply ignored.
+
+This is useful whenever the structure of the graph depends on the data that happens to be
+available:
+
+- **Masked / missing observations** — at each time step (or for each sensor) only some
+  measurements are present, so only those should enter the likelihood.
+- **Data-driven sub-graphs** — a sub-model that branches on a mask and only connects the
+  observed indices, leaving the rest of a conditioned tensor untouched.
+- **Ragged observation sets** — a different number of observations per group, padded into a
+  rectangular array for convenience but only partially used.
+
+## Example
+
+The model below conditions on a length-3 vector `y`, but only references `y[1]` and `y[3]`.
+The value supplied at `y[2]` is never used and has no effect on the result:
+
+```julia
+using RxInfer
+
+@model function partial(y)
+    x ~ NormalMeanVariance(0.0, 100.0)
+    y[1] ~ NormalMeanVariance(x, 1.0)
+    y[3] ~ NormalMeanVariance(x, 1.0)   # y[2] is never referenced
+end
+
+# y[2] = 999.0 is provided but ignored — only y[1] and y[3] inform the posterior.
+result = infer(model = partial(), data = (y = [1.0, 999.0, 3.0],), iterations = 1)
+```
+
+The same applies to multi-dimensional tensors and to data tensors that are sliced and passed
+into sub-models, which is the typical pattern for masked, per-time-step observation blocks:
+
+```julia
+@model function observe(y_, mask_, x)
+    for j in eachindex(mask_)
+        if mask_[j]
+            y_[j] ~ NormalMeanVariance(x, 1.0)
+        end
+    end
+end
+
+@model function masked_chain(y, mask)
+    J, T = size(mask)
+    x ~ NormalMeanVariance(0.0, 100.0)
+    for t in 1:T
+        # `observe` only references the observed sensors of the t-th column of `y`.
+        x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
+    end
+end
+```
+
+## How the data is fed
+
+When a conditioned data array is only partially referenced, the corresponding array of data
+variables is **sparse** — it has the same bounding-box shape as the data, but only the
+referenced indices are materialized. During inference RxInfer feeds the provided data into
+those variables **by index**: the data variable at position `I` receives the value `data[I]`,
+and entries of `data` at unreferenced positions are ignored. You therefore pass `data` with
+its natural, dense shape — no need to pre-mask or reshape it to match the referenced subset.
+
+This applies to both batch inference (`infer` with `data`) and streaming inference (`infer`
+with `datastream`) — in the streaming case each tick's dense value is fed to the materialized
+variables by the same index alignment.
+
+## Notes and caveats
+
+- The provided `data` array must be indexable at every referenced position, i.e. its bounding
+  box must contain all the indices your model touches. Extra (unreferenced) entries are fine.
+- This applies to **data** inputs. Latent (random) variables are normally fully connected; a
+  partially-referenced latent array would leave half-edges in the graph and is not a supported
+  construction.
+- Because unreferenced indices never become part of the graph, they incur no message-passing
+  or memory cost — only the referenced sub-graph is built and run.

--- a/src/callbacks/perfetto.jl
+++ b/src/callbacks/perfetto.jl
@@ -99,17 +99,12 @@ function _to_observability_string(z::Any, _keyname::Symbol)
     # result
 end
 
-_to_observability_string(z::ReactiveMP.RandomVariable, _keyname::Symbol) =
-    "ReactiveMP.RandomVariable(label=$(z.label))"
+_to_observability_string(z::ReactiveMP.RandomVariable, _keyname::Symbol) = "ReactiveMP.RandomVariable(label=$(z.label))"
 
-_to_observability_string(
-    z::Vector{<:ReactiveMP.AbstractMessage}, _keyname::Symbol
-) = "Vector of $(length(z)) messages."
+_to_observability_string(z::Vector{<:ReactiveMP.AbstractMessage}, _keyname::Symbol) = "Vector of $(length(z)) messages."
 
-_to_observability_string(::ReactiveMP.MessageProductContext, _keyname::Symbol) =
-    "<omitted>"
-_to_observability_string(::ReactiveMP.MessageMapping, _keyname::Symbol) =
-    "<omitted>"
+_to_observability_string(::ReactiveMP.MessageProductContext, _keyname::Symbol) = "<omitted>"
+_to_observability_string(::ReactiveMP.MessageMapping, _keyname::Symbol) = "<omitted>"
 _to_observability_string(::ProbabilisticModel, _keyname::Symbol) = "<omitted>"
 
 # Converts a `time_ns()` timestamp to a wall-clock `DateTime` by computing the

--- a/src/inference/batch.jl
+++ b/src/inference/batch.jl
@@ -247,6 +247,16 @@ function batch_inference(;
 
     infer_check_dicttype(:predictvars, predictvars)
 
+    # Offset-indexed (e.g. `OffsetArray`) data is rebased to 1-based indexing during model
+    # construction, which copies it. Warn once per offset-indexed data *input* (not per
+    # element — `pairs(data)` iterates the conditioned arguments), unless `warn = false`.
+    if warn
+        for (key, value) in pairs(data)
+            __incurs_offset_copy(get_data(value)) &&
+                @warn __offset_data_copy_warning(key)
+        end
+    end
+
     model_creation_span_id = generate_span_id(callbacks)
     invoke_callback(callbacks, BeforeModelCreationEvent(model_creation_span_id))
     fmodel = create_model(_model | data)

--- a/src/inference/batch.jl
+++ b/src/inference/batch.jl
@@ -403,7 +403,10 @@ function batch_inference(;
                 BeforeDataUpdateEvent(fmodel, data, data_update_span_id),
             )
             for (key, value) in fdata
-                new_observation!(cacheddatavars[key], get_data(value))
+                # `new_observation_indexed!` aligns by index, so a model that references a
+                # conditioned data tensor only partially (sparse data variables) is fed
+                # correctly from the dense `data` array; dense arrays behave as before.
+                new_observation_indexed!(cacheddatavars[key], get_data(value))
             end
             invoke_callback(
                 callbacks,

--- a/src/inference/streaming.jl
+++ b/src/inference/streaming.jl
@@ -59,7 +59,7 @@ mutable struct RxInferenceEngine{
     ticklock     :: J
 
     # Whether to emit non-fatal warnings during inference (mirrors `infer`'s `warn` keyword).
-    warn :: Bool
+    warn::Bool
 
     RxInferenceEngine(
         ::Type{T},
@@ -393,8 +393,8 @@ function Rocket.on_next!(
                 # A sparse data variable fed an offset value is rebased to 1-based (a per-tick
                 # copy); warn once unless `warn = false` (mirrors the batch entry point).
                 if executor.engine.warn &&
-                   datavar isa GraphPPL.ResizableArray &&
-                   __incurs_offset_copy(value)
+                    datavar isa GraphPPL.ResizableArray &&
+                    __incurs_offset_copy(value)
                     @warn __offset_data_copy_warning(nothing) maxlog = 1
                 end
                 new_observation_indexed!(datavar, value)

--- a/src/inference/streaming.jl
+++ b/src/inference/streaming.jl
@@ -58,6 +58,9 @@ mutable struct RxInferenceEngine{
     error        :: Any
     ticklock     :: J
 
+    # Whether to emit non-fatal warnings during inference (mirrors `infer`'s `warn` keyword).
+    warn :: Bool
+
     RxInferenceEngine(
         ::Type{T},
         datastream::D,
@@ -77,6 +80,7 @@ mutable struct RxInferenceEngine{
         enabledevents::Val{X},
         events::E,
         ticklock::J,
+        warn::Bool = true,
     ) where {T, D, L, V, P, H, S, U, A, FA, FS, R, I, M, N, X, E, J} = begin
         return new{T, D, L, V, P, H, S, U, A, FA, FS, R, I, M, N, X, E, J}(
             datastream,
@@ -103,6 +107,7 @@ mutable struct RxInferenceEngine{
             false,
             nothing,
             ticklock,
+            warn,
         )
     end
 end
@@ -385,6 +390,13 @@ function Rocket.on_next!(
                 # `new_observation_indexed!` aligns by index, so a model that references a
                 # streamed data tensor only partially (sparse data variables) is fed
                 # correctly from the dense streamed value; dense arrays behave as before.
+                # A sparse data variable fed an offset value is rebased to 1-based (a per-tick
+                # copy); warn once unless `warn = false` (mirrors the batch entry point).
+                if executor.engine.warn &&
+                   datavar isa GraphPPL.ResizableArray &&
+                   __incurs_offset_copy(value)
+                    @warn __offset_data_copy_warning(nothing) maxlog = 1
+                end
                 new_observation_indexed!(datavar, value)
             end
             inference_fire_event(
@@ -828,6 +840,7 @@ function streaming_inference(;
         _enabledevents,
         _events,
         _ticklock,
+        warn,
     )
 
     if autostart

--- a/src/inference/streaming.jl
+++ b/src/inference/streaming.jl
@@ -382,7 +382,10 @@ function Rocket.on_next!(
                 event,
             )
             for (datavar, value) in zip(_datavars, values(event))
-                new_observation!(datavar, value)
+                # `new_observation_indexed!` aligns by index, so a model that references a
+                # streamed data tensor only partially (sparse data variables) is fed
+                # correctly from the dense streamed value; dense arrays behave as before.
+                new_observation_indexed!(datavar, value)
             end
             inference_fire_event(
                 Val(:after_data_update),

--- a/src/model/model.jl
+++ b/src/model/model.jl
@@ -215,13 +215,18 @@ function __normalize_data_indexing(data::AbstractArray)
 end
 
 # `true` exactly when `__normalize_data_indexing` would allocate a 1-based copy.
-__incurs_offset_copy(data) = data isa AbstractArray && Base.has_offset_axes(data)
+__incurs_offset_copy(data) =
+    data isa AbstractArray && Base.has_offset_axes(data)
 
 # Shared text for the (cost) warning emitted when offset data is rebased to 1-based indexing.
 # The warning itself is emitted — gated by the `warn` keyword of `infer` — at the batch and
 # streaming entry points, where the copy actually occurs (see `batch_inference` / the streaming feed).
 function __offset_data_copy_warning(name)
-    prefix = isnothing(name) ? "Conditioned data" : string("Conditioned data `", name, "`")
+    prefix = if isnothing(name)
+        "Conditioned data"
+    else
+        string("Conditioned data `", name, "`")
+    end
     return string(
         prefix,
         " uses non-standard (offset) indexing and is copied to standard 1-based indexing for ",

--- a/src/model/model.jl
+++ b/src/model/model.jl
@@ -191,6 +191,46 @@ function Base.show(io::IO, ::DeferredDataHandler)
     print(io, "[ deferred data ]")
 end
 
+"""
+    __normalize_data_indexing(data)
+
+Conditioned data may use non-standard (offset) indexing, e.g. an `OffsetArray` whose axes
+start at `0`. GraphPPL's variable arrays are 1-based and the model's subscripts are bounds-checked
+against the data's axes, so offset-indexed data would otherwise fail at model construction.
+
+This presents such data to the model with standard 1-based axes, preserving the values and their
+iteration order. Models therefore index 1-based (via `1:n`, `eachindex`, `axes`, …) regardless of
+the data's native axes. Standard (already 1-based) arrays — and non-array data — are returned
+unchanged, with no copy. Indexing the model with a literal offset index (e.g. `y[0]`) remains
+unsupported.
+"""
+__normalize_data_indexing(data) = data
+function __normalize_data_indexing(data::AbstractArray)
+    Base.has_offset_axes(data) || return data
+    normalized = Array{eltype(data)}(undef, size(data))
+    @inbounds for (i, value) in enumerate(data)
+        normalized[i] = value
+    end
+    return normalized
+end
+
+# `true` exactly when `__normalize_data_indexing` would allocate a 1-based copy.
+__incurs_offset_copy(data) = data isa AbstractArray && Base.has_offset_axes(data)
+
+# Shared text for the (cost) warning emitted when offset data is rebased to 1-based indexing.
+# The warning itself is emitted — gated by the `warn` keyword of `infer` — at the batch and
+# streaming entry points, where the copy actually occurs (see `batch_inference` / the streaming feed).
+function __offset_data_copy_warning(name)
+    prefix = isnothing(name) ? "Conditioned data" : string("Conditioned data `", name, "`")
+    return string(
+        prefix,
+        " uses non-standard (offset) indexing and is copied to standard 1-based indexing for ",
+        "inference — this incurs an allocation (in streaming inference the copy recurs per tick). ",
+        "Pass a 1-based array (e.g. `collect(x)` or `OffsetArrays.no_offset_view(x)`) to avoid the ",
+        "copy, or set `warn = false` to suppress this warning.",
+    )
+end
+
 # We use the `datalabel` to instantiate the data interface for the model, in case of `DeferredDataHandler`
 # the data is not known at the time of the model creation
 function __infer_create_data_interface(
@@ -214,7 +254,7 @@ function __infer_create_data_interface(
         context,
         GraphPPL.NodeCreationOptions(; kind = :data, factorized = false),
         key,
-        get_data(data),
+        __normalize_data_indexing(get_data(data)),
     )
 end
 
@@ -225,7 +265,7 @@ function __infer_create_data_interface(model, context, key::Symbol, data)
         context,
         GraphPPL.NodeCreationOptions(; kind = :data, factorized = true),
         key,
-        data,
+        __normalize_data_indexing(data),
     )
 end
 

--- a/src/model/model.jl
+++ b/src/model/model.jl
@@ -191,19 +191,17 @@ function Base.show(io::IO, ::DeferredDataHandler)
     print(io, "[ deferred data ]")
 end
 
-"""
-    __normalize_data_indexing(data)
-
-Conditioned data may use non-standard (offset) indexing, e.g. an `OffsetArray` whose axes
-start at `0`. GraphPPL's variable arrays are 1-based and the model's subscripts are bounds-checked
-against the data's axes, so offset-indexed data would otherwise fail at model construction.
-
-This presents such data to the model with standard 1-based axes, preserving the values and their
-iteration order. Models therefore index 1-based (via `1:n`, `eachindex`, `axes`, …) regardless of
-the data's native axes. Standard (already 1-based) arrays — and non-array data — are returned
-unchanged, with no copy. Indexing the model with a literal offset index (e.g. `y[0]`) remains
-unsupported.
-"""
+# __normalize_data_indexing(data)
+#
+# Conditioned data may use non-standard (offset) indexing, e.g. an `OffsetArray` whose axes
+# start at `0`. GraphPPL's variable arrays are 1-based and the model's subscripts are bounds-checked
+# against the data's axes, so offset-indexed data would otherwise fail at model construction.
+#
+# This presents such data to the model with standard 1-based axes, preserving the values and their
+# iteration order. Models therefore index 1-based (via `1:n`, `eachindex`, `axes`, …) regardless of
+# the data's native axes. Standard (already 1-based) arrays — and non-array data — are returned
+# unchanged, with no copy. Indexing the model with a literal offset index (e.g. `y[0]`) remains
+# unsupported.
 __normalize_data_indexing(data) = data
 function __normalize_data_indexing(data::AbstractArray)
     Base.has_offset_axes(data) || return data

--- a/src/model/plugins/reactivemp_inference.jl
+++ b/src/model/plugins/reactivemp_inference.jl
@@ -648,6 +648,9 @@ new_observation_indexed!(datavars, data) =
 function new_observation_indexed!(
     datavars::GraphPPL.ResizableArray, data::AbstractArray
 )
+    # The label array is 1-based; normalize offset-indexed `data` so the per-index alignment
+    # below (`data[I]`, with 1-based `I`) reads the intended values (see `__normalize_data_indexing`).
+    data = __normalize_data_indexing(data)
     _is_densely_assigned(datavars) &&
         return ReactiveMP.new_observation!(datavars, data)
     for I in CartesianIndices(size(datavars))

--- a/src/model/plugins/reactivemp_inference.jl
+++ b/src/model/plugins/reactivemp_inference.jl
@@ -568,8 +568,10 @@ getlabel(ref::GraphVariableRef) = ref.label
 getvariable(ref::GraphVariableRef) = ref.variable
 getname(ref::GraphVariableRef) = GraphPPL.getname(getlabel(ref))
 
+# `vec` (GraphPPL's `ResizableArray` method) yields only the *assigned* entries, so these
+# predicates are well-defined for sparse containers (a sparse data tensor is still "all data").
 GraphPPL.is_data(collection::AbstractArray{GraphVariableRef}) =
-    all(GraphPPL.is_data, collection)
+    all(GraphPPL.is_data, vec(collection))
 
 GraphPPL.is_data(ref::GraphVariableRef) = GraphPPL.is_data(ref.properties)
 GraphPPL.is_random(ref::GraphVariableRef) = GraphPPL.is_random(ref.properties)
@@ -597,10 +599,64 @@ getvarref(model::GraphPPL.Model, label::GraphPPL.NodeLabel) =
     GraphVariableRef(model, label)
 getvarref(model::GraphPPL.Model, container::AbstractArray) =
     map(element -> getvarref(model, element), container)
+getvarref(model::GraphPPL.Model, container::GraphPPL.ResizableArray) =
+    _map_sparse(element -> getvarref(model, element), container)
+
+# --- Sparse variable arrays -------------------------------------------------------------
+#
+# A `GraphPPL.ResizableArray` may be *sparse*: indexed only at some positions within its
+# bounding box, leaving the rest as `#undef` holes. This arises for data tensors that are
+# conditioned on but only *partially referenced* in the model — e.g. masked / missing
+# observations, where a sub-model only touches the observed indices and the remaining
+# entries of the conditioned array are never used. GraphPPL's `iterate`/`Base.map` over
+# such an array are deliberately dense (so `length`/`collect` stay consistent) and would
+# trip over the holes with an `UndefRefError`. The helpers below iterate only the
+# *assigned* entries instead, mirroring the sparse-aware `vec`/`isassigned` API.
+
+# Whether every index within a container's bounding box is assigned. Plain `AbstractArray`s
+# (and densely-built `ResizableArray`s) are dense; only partially-indexed `ResizableArray`s
+# are sparse. Used to keep the common dense path allocation- and behaviour-identical.
+_is_densely_assigned(::AbstractArray) = true
+_is_densely_assigned(container::GraphPPL.ResizableArray) =
+    all(I -> isassigned(container, I.I...), CartesianIndices(size(container)))
+
+# Apply `f` to a (possibly sparse) `ResizableArray`, preserving its shape. Dense arrays take
+# the fast path identical to `Base.map` (returning a plain `Array`); sparse arrays map only
+# their assigned entries into a new `ResizableArray`, leaving the holes as holes.
+function _map_sparse(f::F, container::GraphPPL.ResizableArray) where {F}
+    _is_densely_assigned(container) && return map(f, container)
+    indices = filter(I -> isassigned(container, I.I...), collect(CartesianIndices(size(container))))
+    values  = [f(container[I.I...]) for I in indices]
+    result  = GraphPPL.ResizableArray(eltype(values), Val(ndims(container)))
+    for (value, I) in zip(values, indices)
+        result[I.I...] = value
+    end
+    return result
+end
 
 getvariable(nodedata::GraphPPL.NodeData) =
     getextra(nodedata, ReactiveMPExtraVariableKey)
 getvariable(container::AbstractArray) = map(getvariable, container)
+getvariable(container::GraphPPL.ResizableArray) =
+    _map_sparse(getvariable, container)
+
+# Feed a new observation into a (possibly sparse) array of data variables, aligning by index:
+# `datavars[I]` receives `data[I]` for every *assigned* `I`. Entries of the provided `data`
+# that the model never referenced are ignored. Dense arrays defer to `ReactiveMP` as before.
+new_observation_indexed!(datavars, data) =
+    ReactiveMP.new_observation!(datavars, data)
+function new_observation_indexed!(
+    datavars::GraphPPL.ResizableArray, data::AbstractArray
+)
+    _is_densely_assigned(datavars) &&
+        return ReactiveMP.new_observation!(datavars, data)
+    for I in CartesianIndices(size(datavars))
+        if isassigned(datavars, I.I...)
+            ReactiveMP.new_observation!(datavars[I.I...], data[I])
+        end
+    end
+    return nothing
+end
 
 function getrandomvars(model::GraphPPL.Model)
     # TODO improve performance here
@@ -644,18 +700,18 @@ obtain_marginal(ref::GraphVariableRef) =
 obtain_marginal(refs::AbstractArray) = collectLatest(map(obtain_marginal, refs))
 
 ReactiveMP.israndom(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.israndom, collection)
+    all(ReactiveMP.israndom, vec(collection))
 ReactiveMP.isdata(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.isdata, collection)
+    all(ReactiveMP.isdata, vec(collection))
 ReactiveMP.isconst(collection::AbstractArray{GraphVariableRef}) =
-    all(ReactiveMP.isconst, collection)
+    all(ReactiveMP.isconst, vec(collection))
 
 ReactiveMP.israndom(ref::GraphVariableRef) = GraphPPL.is_random(ref.properties)
 ReactiveMP.isdata(ref::GraphVariableRef) = GraphPPL.is_data(ref.properties)
 ReactiveMP.isconst(ref::GraphVariableRef) = GraphPPL.is_constant(ref.properties)
 
 isanonymous(collection::AbstractArray{GraphVariableRef}) =
-    all(isanonymous, collection)
+    all(isanonymous, vec(collection))
 isanonymous(ref::GraphVariableRef) = GraphPPL.is_anonymous(ref.properties)
 
 # Form constraint preprocessing 

--- a/test/inference/sparse_data_tests.jl
+++ b/test/inference/sparse_data_tests.jl
@@ -190,7 +190,9 @@ end
 
     ys = [10.0, 20.0, 30.0]
     check(model, ydata, observed) = begin
-        q = last(infer(model = model, data = (y = ydata,), iterations = 1).posteriors[:x])
+        q = last(
+            infer(model = model, data = (y = ydata,), iterations = 1).posteriors[:x],
+        )
         @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
         @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
     end
@@ -215,7 +217,9 @@ end
     end
 
     check(ydata) = begin
-        q = last(infer(model = obs_sparse(), data = (y = ydata,), iterations = 1).posteriors[:x])
+        q = last(
+            infer(model = obs_sparse(), data = (y = ydata,), iterations = 1).posteriors[:x],
+        )
         @test isapprox(precision(q), 1 / 100 + 2; atol = 1e-8)        # two observations
         @test isapprox(weightedmean(q), 10.0 + 30.0; atol = 1e-8)     # 1st and 3rd values, 2nd ignored
     end
@@ -258,7 +262,7 @@ end
         end
     end
 
-    flips  = [1.0, 0.0, 1.0, 1.0, 0.0]
+    flips = [1.0, 0.0, 1.0, 1.0, 0.0]
     offset = OffsetArray(flips, 0:4)
     has_offset_warn(logs) =
         any(l -> l.level == Logging.Warn && occursin("offset", l.message), logs)

--- a/test/inference/sparse_data_tests.jl
+++ b/test/inference/sparse_data_tests.jl
@@ -1,0 +1,190 @@
+# Tests for inference over *partially-referenced* (sparse) conditioned data tensors.
+#
+# When a model conditions on a data array but only references some of its indices in `~`
+# statements (e.g. masked / missing observations, or a sub-model that only touches the
+# observed entries), GraphPPL materializes data-variable labels only at those indices,
+# leaving the rest of the bounding box as `#undef` holes. Result collection
+# (`getvardict`/`getvarref`), the random/data/anonymous predicates, and the per-iteration
+# data feed must all tolerate such sparse arrays — iterating only the assigned entries —
+# and the dense data the user supplies must be fed to the materialized variables by index.
+
+@testitem "Inference with a 1-D sparse (partially-referenced) data tensor" begin
+    @model function partial_1d(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # y[2] is never referenced -> a hole
+    end
+
+    # y[2] = 999.0 is supplied but never referenced; it must be ignored entirely.
+    result = infer(
+        model = partial_1d(), data = (y = [1.0, 999.0, 3.0],), iterations = 1
+    )
+    q = last(result.posteriors[:x])
+
+    # x ~ N(0, 100) with two unit-variance observations 1.0 and 3.0:
+    @test isapprox(precision(q), 1 / 100 + 2; atol = 1e-8)
+    @test isapprox(weightedmean(q), 0 / 100 + (1.0 + 3.0); atol = 1e-8)
+end
+
+@testitem "Inference with a 2-D sparse data tensor" begin
+    @model function partial_2d(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1, 1] ~ NormalMeanVariance(x, 1.0)
+        y[2, 2] ~ NormalMeanVariance(x, 1.0)
+        y[1, 3] ~ NormalMeanVariance(x, 1.0) # (2,1),(1,2),(2,3) are holes
+    end
+
+    data = reshape(collect(1.0:6.0), 2, 3) # [1 3 5; 2 4 6]
+    result = infer(model = partial_2d(), data = (y = data,), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    observed = [data[1, 1], data[2, 2], data[1, 3]] # 1.0, 4.0, 5.0
+    @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
+end
+
+@testitem "Inference with a sub-model that references data only at masked positions" begin
+    # `x` is the missing interface, so `x ~ observe(...)` binds the shared latent.
+    @model function observe(y_, mask_, x)
+        for j in eachindex(mask_)
+            if mask_[j]
+                y_[j] ~ NormalMeanVariance(x, 1.0)
+            end
+        end
+    end
+
+    @model function masked_chain(y, mask)
+        J, T = size(mask)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        for t in 1:T
+            x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
+        end
+    end
+
+    J, T = 2, 3
+    mask = Bool[1 0 1; 0 1 0] # observed: (1,1), (2,2), (1,3)
+    data = reshape(collect(1.0:6.0), J, T) # [1 3 5; 2 4 6]
+    result = infer(
+        model = masked_chain(mask = mask), data = (y = data,), iterations = 1
+    )
+    q = last(result.posteriors[:x])
+
+    observed = [data[idx] for idx in findall(mask)] # 1.0, 4.0, 5.0
+    @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
+end
+
+@testitem "Dense data tensors are unaffected by the sparse-array handling" begin
+    @model function dense_model(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        for i in eachindex(y)
+            y[i] ~ NormalMeanVariance(x, 1.0)
+        end
+    end
+
+    ys = [1.0, 2.0, 3.0]
+    result = infer(model = dense_model(), data = (y = ys,), iterations = 1)
+    q = last(result.posteriors[:x])
+
+    @test isapprox(precision(q), 1 / 100 + length(ys); atol = 1e-8)
+    @test isapprox(weightedmean(q), sum(ys); atol = 1e-8)
+end
+
+@testitem "Sparse-array helpers (_is_densely_assigned / _map_sparse)" begin
+    import RxInfer: _is_densely_assigned, _map_sparse
+    import GraphPPL: ResizableArray
+
+    # Plain arrays are always dense.
+    @test _is_densely_assigned([1, 2, 3])
+    @test _is_densely_assigned(reshape(1:6, 2, 3))
+
+    # A densely-built ResizableArray is dense; `_map_sparse` matches `Base.map` (returns Array).
+    dense = ResizableArray(Int, Val(1))
+    dense[1] = 1;
+    dense[2] = 2;
+    dense[3] = 3
+    @test _is_densely_assigned(dense)
+    mapped = _map_sparse(x -> x + 10, dense)
+    @test mapped isa Array
+    @test mapped == [11, 12, 13]
+
+    # A 1-D ResizableArray with a hole (use a non-bitstype so the hole is a true `#undef`).
+    sparse1 = ResizableArray(String, Val(1))
+    sparse1[1] = "a";
+    sparse1[3] = "c" # index 2 is a hole
+    @test !_is_densely_assigned(sparse1)
+    res1 = _map_sparse(uppercase, sparse1)
+    @test res1 isa ResizableArray
+    @test size(res1) == (3,)
+    @test isassigned(res1, 1) && !isassigned(res1, 2) && isassigned(res1, 3)
+    @test res1[1] == "A" && res1[3] == "C"
+
+    # A 2-D ResizableArray with holes preserves shape and assigned positions.
+    sparse2 = ResizableArray(String, Val(2))
+    sparse2[1, 1] = "x";
+    sparse2[2, 2] = "y";
+    sparse2[1, 3] = "z"
+    @test !_is_densely_assigned(sparse2)
+    res2 = _map_sparse(uppercase, sparse2)
+    @test res2 isa ResizableArray
+    @test res2[1, 1] == "X" && res2[2, 2] == "Y" && res2[1, 3] == "Z"
+    @test !isassigned(res2, 2, 1) && !isassigned(res2, 1, 2)
+end
+
+@testitem "Streaming inference with a partially-referenced (sparse) data tensor" begin
+    import RxInfer: from
+
+    @model function ssm_sparse(y, xm, xv)
+        x ~ NormalMeanVariance(xm, xv)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # y[2] never referenced -> hole
+    end
+
+    autoupdates = @autoupdates begin
+        xm, xv = mean_var(q(x))
+    end
+
+    run_stream(y2a, y2b) = begin
+        engine = infer(
+            model          = ssm_sparse(),
+            datastream     = from([(y = [1.0, y2a, 3.0],), (y = [2.0, y2b, 4.0],)]),
+            autoupdates    = autoupdates,
+            initialization = (@initialization begin
+                q(x) = NormalMeanVariance(0.0, 100.0)
+            end),
+            historyvars    = (x = KeepLast(),),
+            keephistory    = 10,
+            autostart      = true,
+        )
+        return engine.history[:x]
+    end
+
+    # Runs at all (previously: UndefRefError in `getvardict` before the stream started).
+    h1 = run_stream(999.0, -777.0)
+    @test length(h1) == 2
+    @test all(isfinite ∘ mean, h1)
+
+    # The unreferenced entry y[2] must have no effect on the inferred trajectory.
+    h2 = run_stream(-12345.0, 54321.0)
+    @test all(isapprox.(mean.(h1), mean.(h2); atol = 1e-10))
+    @test all(isapprox.(var.(h1), var.(h2); atol = 1e-10))
+end
+
+@testitem "new_observation_indexed! feeds sparse data variables by index" begin
+    import RxInfer: new_observation_indexed!
+    import GraphPPL: ResizableArray
+    const RMP = RxInfer.ReactiveMP
+
+    readback(dv) = RMP.getdata(RxInfer.Rocket.getrecent(dv.messageout))
+
+    # Build a sparse array of data variables with a hole at index 2.
+    vars = ResizableArray(typeof(RMP.datavar()), Val(1))
+    vars[1] = RMP.datavar()
+    vars[3] = RMP.datavar() # index 2 is a hole
+
+    # The provided dense data has 3 entries; index 2 (999.0) must be ignored.
+    new_observation_indexed!(vars, [10.0, 999.0, 30.0])
+
+    @test readback(vars[1]) == PointMass(10.0)
+    @test readback(vars[3]) == PointMass(30.0)
+end

--- a/test/inference/sparse_data_tests.jl
+++ b/test/inference/sparse_data_tests.jl
@@ -170,6 +170,153 @@ end
     @test all(isapprox.(var.(h1), var.(h2); atol = 1e-10))
 end
 
+@testitem "Conditioning on offset-indexed (OffsetArray) data with 1-based model indexing" begin
+    using OffsetArrays
+
+    # Model indexes 1-based explicitly.
+    @model function obs_1based(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[2] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0)
+    end
+    # Model indexes via eachindex (after normalization, eachindex(y) is 1-based).
+    @model function obs_eachindex(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        for i in eachindex(y)
+            y[i] ~ NormalMeanVariance(x, 1.0)
+        end
+    end
+
+    ys = [10.0, 20.0, 30.0]
+    check(model, ydata, observed) = begin
+        q = last(infer(model = model, data = (y = ydata,), iterations = 1).posteriors[:x])
+        @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
+        @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
+    end
+
+    # Baseline (1-based) is unchanged.
+    check(obs_1based(), ys, ys)
+    # 0-based OffsetArray: previously errored at construction; now normalized to 1-based.
+    check(obs_1based(), OffsetArray(ys, 0:2), ys)
+    # Negative-based OffsetArray.
+    check(obs_1based(), OffsetArray(ys, -1:1), ys)
+    # `eachindex` over offset data now yields 1-based indices.
+    check(obs_eachindex(), OffsetArray(ys, 0:2), ys)
+end
+
+@testitem "Offset-indexed data combined with sparse (partial) referencing" begin
+    using OffsetArrays
+
+    @model function obs_sparse(y)
+        x ~ NormalMeanVariance(0.0, 100.0)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # y[2] (1-based) unreferenced -> sparse
+    end
+
+    check(ydata) = begin
+        q = last(infer(model = obs_sparse(), data = (y = ydata,), iterations = 1).posteriors[:x])
+        @test isapprox(precision(q), 1 / 100 + 2; atol = 1e-8)        # two observations
+        @test isapprox(weightedmean(q), 10.0 + 30.0; atol = 1e-8)     # 1st and 3rd values, 2nd ignored
+    end
+
+    check([10.0, 999.0, 30.0])                       # standard, sanity
+    check(OffsetArray([10.0, 999.0, 30.0], 0:2))     # offset + sparse
+    check(OffsetArray([10.0, 999.0, 30.0], -1:1))    # negative-based + sparse
+end
+
+@testitem "__normalize_data_indexing leaves standard data untouched and rebases offset data" begin
+    import RxInfer: __normalize_data_indexing
+    using OffsetArrays
+
+    # Non-arrays and 1-based arrays are returned unchanged (same object, no copy).
+    @test __normalize_data_indexing(3.0) === 3.0
+    v = [1.0, 2.0, 3.0]
+    @test __normalize_data_indexing(v) === v
+    m = [1.0 2.0; 3.0 4.0]
+    @test __normalize_data_indexing(m) === m
+
+    # Offset arrays are rebased to 1-based, preserving values and order.
+    o = OffsetArray([10.0, 20.0, 30.0], 0:2)
+    n = __normalize_data_indexing(o)
+    @test axes(n) == (Base.OneTo(3),)
+    @test n == [10.0, 20.0, 30.0]
+
+    o2 = OffsetArray([1.0 2.0; 3.0 4.0], 0:1, 0:1)
+    n2 = __normalize_data_indexing(o2)
+    @test axes(n2) == (Base.OneTo(2), Base.OneTo(2))
+    @test n2 == [1.0 2.0; 3.0 4.0]
+end
+
+@testitem "Offset data emits a `warn`-gated copy warning (batch)" begin
+    using OffsetArrays, Logging
+
+    @model function coin(y)
+        θ ~ Beta(1.0, 1.0)
+        for i in eachindex(y)
+            y[i] ~ Bernoulli(θ)
+        end
+    end
+
+    flips  = [1.0, 0.0, 1.0, 1.0, 0.0]
+    offset = OffsetArray(flips, 0:4)
+    has_offset_warn(logs) =
+        any(l -> l.level == Logging.Warn && occursin("offset", l.message), logs)
+
+    # standard 1-based data: no copy, no warning
+    logs, _ = Test.collect_test_logs() do
+        infer(model = coin(), data = (y = flips,))
+    end
+    @test !has_offset_warn(logs)
+
+    # offset data, default warn = true: warning emitted
+    logs, _ = Test.collect_test_logs() do
+        infer(model = coin(), data = (y = offset,))
+    end
+    @test has_offset_warn(logs)
+
+    # offset data, warn = false: suppressed
+    logs, _ = Test.collect_test_logs() do
+        infer(model = coin(), data = (y = offset,), warn = false)
+    end
+    @test !has_offset_warn(logs)
+end
+
+@testitem "Offset data emits a `warn`-gated copy warning (streaming, sparse var)" begin
+    using OffsetArrays, Logging
+    import RxInfer: from
+
+    @model function ssm(y, xm, xv)
+        x ~ NormalMeanVariance(xm, xv)
+        y[1] ~ NormalMeanVariance(x, 1.0)
+        y[3] ~ NormalMeanVariance(x, 1.0) # sparse: y[2] unreferenced
+    end
+    autoupdates = @autoupdates begin
+        xm, xv = mean_var(q(x))
+    end
+
+    run_stream(warnflag) = Test.collect_test_logs() do
+        infer(
+            model          = ssm(),
+            datastream     = from([(y = OffsetArray([1.0, 999.0, 3.0], 0:2),)]),
+            autoupdates    = autoupdates,
+            initialization = (@initialization begin
+                q(x) = NormalMeanVariance(0.0, 100.0)
+            end),
+            keephistory    = 1,
+            autostart      = true,
+            warn           = warnflag,
+        )
+    end
+    has_offset_warn(logs) =
+        any(l -> l.level == Logging.Warn && occursin("offset", l.message), logs)
+
+    logs_on, _  = run_stream(true)
+    logs_off, _ = run_stream(false)
+    @test has_offset_warn(logs_on)
+    @test !has_offset_warn(logs_off)
+end
+
 @testitem "new_observation_indexed! feeds sparse data variables by index" begin
     import RxInfer: new_observation_indexed!
     import GraphPPL: ResizableArray


### PR DESCRIPTION
This PR allows conditioning on dense datasets where during model construction only some indices contribute to the final graph; other entries are properly ignored. Also non-standard data indexing (like OffsetArrays.jl) Full description below:


# [Partially-referenced (sparse) data](@id partial-data)

RxInfer materializes the nodes of a conditioned data array **lazily**: a data variable is
created only for the indices that your model actually references inside a `~` statement.
This means you can condition on a *full, dense* data array but only wire up the entries that
are relevant for a particular run — the unreferenced entries are simply ignored.

This is useful whenever the structure of the graph depends on the data that happens to be
available:

- **Masked / missing observations** — at each time step (or for each sensor) only some
  measurements are present, so only those should enter the likelihood.
- **Data-driven sub-graphs** — a sub-model that branches on a mask and only connects the
  observed indices, leaving the rest of a conditioned tensor untouched.
- **Ragged observation sets** — a different number of observations per group, padded into a
  rectangular array for convenience but only partially used.

## Example

The model below conditions on a length-3 vector `y`, but only references `y[1]` and `y[3]`.
The value supplied at `y[2]` is never used and has no effect on the result:

```julia
using RxInfer

@model function partial(y)
    x ~ NormalMeanVariance(0.0, 100.0)
    y[1] ~ NormalMeanVariance(x, 1.0)
    y[3] ~ NormalMeanVariance(x, 1.0)   # y[2] is never referenced
end

# y[2] = 999.0 is provided but ignored — only y[1] and y[3] inform the posterior.
result = infer(model = partial(), data = (y = [1.0, 999.0, 3.0],), iterations = 1)
```

The same applies to multi-dimensional tensors and to data tensors that are sliced and passed
into sub-models, which is the typical pattern for masked, per-time-step observation blocks:

```julia
@model function observe(y_, mask_, x)
    for j in eachindex(mask_)
        if mask_[j]
            y_[j] ~ NormalMeanVariance(x, 1.0)
        end
    end
end

@model function masked_chain(y, mask)
    J, T = size(mask)
    x ~ NormalMeanVariance(0.0, 100.0)
    for t in 1:T
        # `observe` only references the observed sensors of the t-th column of `y`.
        x ~ observe(y_ = y[1:J, t:t], mask_ = mask[1:J, t:t])
    end
end
```

## How the data is fed

When a conditioned data array is only partially referenced, the corresponding array of data
variables is **sparse** — it has the same bounding-box shape as the data, but only the
referenced indices are materialized. During inference RxInfer feeds the provided data into
those variables **by index**: the data variable at position `I` receives the value `data[I]`,
and entries of `data` at unreferenced positions are ignored. You therefore pass `data` with
its natural, dense shape — no need to pre-mask or reshape it to match the referenced subset.

This applies to both batch inference (`infer` with `data`) and streaming inference (`infer`
with `datastream`) — in the streaming case each tick's dense value is fed to the materialized
variables by the same index alignment.

## Non-standard (offset) data indexing

Conditioned data may use **non-standard indexing**, such as an `OffsetArray` whose axes start
at `0` (or at a negative index). RxInfer presents such data to the model with standard 1-based
axes — the values and their order are preserved, only the addressing is rebased. You therefore
write your model with ordinary 1-based indexing (`1:n`, `eachindex`, `axes`, …) regardless of
the data's native axes, and partial/sparse referencing works exactly as above:

```julia
using RxInfer, OffsetArrays

@model function partial(y)
    x ~ NormalMeanVariance(0.0, 100.0)
    y[1] ~ NormalMeanVariance(x, 1.0)
    y[3] ~ NormalMeanVariance(x, 1.0)
end

# A 0-based OffsetArray is accepted; the model still indexes 1-based.
ydata  = OffsetArray([1.0, 999.0, 3.0], 0:2)
result = infer(model = partial(), data = (y = ydata,), iterations = 1)
```

Standard (already 1-based) arrays are passed through unchanged, with no copy. Note that
indexing the model itself with a literal offset index (e.g. writing `y[0]` inside `@model`)
is **not** supported — variable arrays are 1-based; only the *data*'s indexing is rebased.

!!! note "Rebasing incurs a copy"
    Rebasing offset data to 1-based indexing allocates a copy of the array (once per `infer`
    call for batch inference; once per tick for the affected variable in streaming inference).
    A warning is emitted when this happens, gated by the `warn` keyword of [`infer`](@ref) (set
    `warn = false` to silence it). To avoid the copy entirely, pass a 1-based array — e.g.
    `collect(x)` or `OffsetArrays.no_offset_view(x)`. Standard 1-based data incurs no copy and no
    warning.

## Notes and caveats

- The provided `data` array must be indexable at every referenced position, i.e. its bounding
  box must contain all the indices your model touches. Extra (unreferenced) entries are fine.
- This applies to **data** inputs. Latent (random) variables are normally fully connected; a
  partially-referenced latent array would leave half-edges in the graph and is not a supported
  construction.
- Because unreferenced indices never become part of the graph, they incur no message-passing
  or memory cost — only the referenced sub-graph is built and run.