### PR TITLE
PR — Fix `UndefVarError: data not defined` in `__add_document` (session sharing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `RxInfer.share_session_data()` no longer throws `UndefVarError: data not defined` when re-uploading an already-registered document (the PATCH branch of `__add_document`). Repeat manual sharing and automatic session sharing (which hits this path on every inference call after the first) now update the existing Firestore document correctly. Added a regression test that exercises the update branch without network access. ([#679](https://github.com/ReactiveBayes/RxInfer.jl/issues/679))
+
 ## [5.5.0] - 2026-06-18
 
 ### Added

--- a/src/telemetry.jl
+++ b/src/telemetry.jl
@@ -135,11 +135,23 @@ const collection_allow_patch = Dict{String, Bool}(
 )
 
 # Adds or updates a document in Firestore based on the provided id and collection.
-# If a document with the same id already exists (tracked in id_name_mapping), 
+# If a document with the same id already exists (tracked in id_name_mapping),
 # it updates that document instead of creating a new one to avoid duplicates.
 # The document name from Firestore is stored in id_name_mapping for future updates.
-function __add_document(id, collection, payload)
-    if !isnothing(preference_telemetry_endpoint)
+#
+# The `endpoint`, `http_post` and `http_patch` keyword arguments exist purely to make
+# this function testable without performing real network requests: tests inject the
+# base endpoint and stub HTTP verbs that capture their arguments. In normal operation
+# they default to the configured telemetry endpoint and the real `HTTP.post`/`HTTP.patch`.
+function __add_document(
+    id,
+    collection,
+    payload;
+    endpoint = preference_telemetry_endpoint,
+    http_post = HTTP.post,
+    http_patch = HTTP.patch,
+)
+    if !isnothing(endpoint)
         # Headers required for Firestore REST API
         headers = [
             "Accept" => "application/json", "Content-Type" => "application/json"
@@ -156,20 +168,16 @@ function __add_document(id, collection, payload)
         # Firestore document structure
         # See: https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents
         response = if haskey(id_name_mapping, id)
-            # If document exists, endpoint should look like:
+            # If document exists, request endpoint should look like:
             # "https://firestore.../using_rxinfer/abc123def456"
             name = id_name_mapping[id]
-            endpoint = string(
-                rstrip(preference_telemetry_endpoint, '/'),
-                '/',
-                collection,
-                '/',
-                name,
+            request_endpoint = string(
+                rstrip(endpoint, '/'), '/', collection, '/', name
             )
             # For collections that allow patching (like using_rxinfer, sessions, session_stats),
             # send a PATCH request to update the existing document with new data
             if collection_allow_patch[collection]
-                HTTP.patch(endpoint, headers, JSON.json(payload))
+                http_patch(request_endpoint, headers, JSON.json(payload))
                 # For collections that don't allow patching (like invokes),
                 # return a fake successful response without making a request,
                 # since we don't want to update existing documents in these collections
@@ -177,12 +185,10 @@ function __add_document(id, collection, payload)
                 (body = """{"name": "$name"}""", status = 200)
             end
         else
-            # For new documents, endpoint would be like:
+            # For new documents, request endpoint would be like:
             # "https://firestore.../using_rxinfer"
-            endpoint = string(
-                rstrip(preference_telemetry_endpoint, '/'), '/', collection
-            )
-            HTTP.post(endpoint, headers, JSON.json(payload))
+            request_endpoint = string(rstrip(endpoint, '/'), '/', collection)
+            http_post(request_endpoint, headers, JSON.json(payload))
         end
 
         # Parse response if successful

--- a/src/telemetry.jl
+++ b/src/telemetry.jl
@@ -169,7 +169,7 @@ function __add_document(id, collection, payload)
             # For collections that allow patching (like using_rxinfer, sessions, session_stats),
             # send a PATCH request to update the existing document with new data
             if collection_allow_patch[collection]
-                HTTP.patch(endpoint, headers, JSON.json(data))
+                HTTP.patch(endpoint, headers, JSON.json(payload))
                 # For collections that don't allow patching (like invokes),
                 # return a fake successful response without making a request,
                 # since we don't want to update existing documents in these collections

--- a/test/session_tests.jl
+++ b/test/session_tests.jl
@@ -289,3 +289,74 @@ end
     last_invoke = stats.invokes[end]
     @test last_invoke.context[:a] === 1
 end
+
+@testitem "__add_document should PATCH an already-registered document without error (issue #679)" begin
+    using UUIDs, JSON
+
+    # Stub HTTP verbs so no real network request is performed. They capture their
+    # arguments and return a minimal Firestore-like response.
+    post_calls = Ref(0)
+    patch_calls = Ref(0)
+    captured = Ref{Any}(nothing)
+
+    response = (
+        status = 200,
+        body = """{"name": "projects/x/databases/(default)/documents/sessions/generated-name"}""",
+    )
+
+    fake_post =
+        (url, headers, body) -> begin
+            post_calls[] += 1
+            captured[] = (verb = :post, url = url, body = body)
+            return response
+        end
+    fake_patch =
+        (url, headers, body) -> begin
+            patch_calls[] += 1
+            captured[] = (verb = :patch, url = url, body = body)
+            return response
+        end
+
+    endpoint = "https://example.test/documents"
+    id = string(uuid4())
+
+    try
+        # First upload of a fresh id -> POST branch, populates `id_name_mapping`.
+        payload1 = (; fields = (; x = (; stringValue = "a")))
+        name1 = RxInfer.__add_document(
+            id,
+            "sessions",
+            payload1;
+            endpoint = endpoint,
+            http_post = fake_post,
+            http_patch = fake_patch,
+        )
+        @test post_calls[] == 1
+        @test patch_calls[] == 0
+        @test name1 == "generated-name"
+        @test captured[].verb == :post
+        @test haskey(RxInfer.id_name_mapping, id)
+
+        # Second upload of the SAME id -> PATCH branch. Before the fix this threw
+        # `UndefVarError: data not defined` because the branch serialised an undefined
+        # `data` instead of the `payload` parameter.
+        payload2 = (; fields = (; x = (; stringValue = "b")))
+        name2 = RxInfer.__add_document(
+            id,
+            "sessions",
+            payload2;
+            endpoint = endpoint,
+            http_post = fake_post,
+            http_patch = fake_patch,
+        )
+        @test patch_calls[] == 1
+        @test captured[].verb == :patch
+        # The PATCH request must carry the serialised `payload`, not `data`.
+        @test captured[].body == JSON.json(payload2)
+        # The PATCH endpoint must target the previously registered document name.
+        @test endswith(captured[].url, "/sessions/generated-name")
+        @test name2 == "generated-name"
+    finally
+        delete!(RxInfer.id_name_mapping, id)
+    end
+end


### PR DESCRIPTION
Closes: issue-01-telemetry-undefined-data (MEDIUM)

## Summary

One-line fix. `__add_document(id, collection, payload)` used `JSON.json(data)` in the
already-uploaded-document (PATCH) branch, but the parameter is named `payload`. The referenced
`data` is undefined, so any second upload of the same session/stats document id throws
`UndefVarError` (manual share) or silently fails (automatic share). Change `data` → `payload`.

## Code change

File: `src/telemetry.jl`

```diff
             # For collections that allow patching (like using_rxinfer, sessions, session_stats),
             # send a PATCH request to update the existing document with new data
             if collection_allow_patch[collection]
-                HTTP.patch(endpoint, headers, JSON.json(data))
+                HTTP.patch(endpoint, headers, JSON.json(payload))
```

## Why this is correct

- `payload` is the third parameter of `__add_document(id, collection, payload)` (line 141) and is
  what the new-document POST branch already serialises (`JSON.json(payload)`, line 185).
- A runtime reproduction confirms the bug and that `data` is not defined anywhere in `RxInfer`
  (`isdefined(RxInfer, :data) === false`).

## Verification

1. Reproduce pre-fix:

```julia
using RxInfer
RxInfer.id_name_mapping["some-id"] = "some-doc"
try; RxInfer.__add_document("some-id", "sessions", (; fields=(; x=(; stringValue="a")))); catch e; println(e); end
# before: UndefVarError: `data` not defined in `RxInfer`
```

2. After the fix, the PATCH branch serialises `payload` (a real network PATCH now occurs when a
   Firestore endpoint is configured). Unit/full suite (`made test`/`Pkg.test`) should remain green —
   no behaviour change on the fresh-document path.

## Test coverage note

There is currently **no test** exercising `__add_document`'s update branch (session tests only cover
in-memory stats). Recommend adding a test (e.g. against a stub endpoint) so this regression is caught
in future.