### PR TITLE
test: suppress intentional offset-indexing warnings in sparse data tests

### DIFF
--- a/test/inference/sparse_data_tests.jl
+++ b/test/inference/sparse_data_tests.jl
@@ -189,9 +189,17 @@ end
     end
 
     ys = [10.0, 20.0, 30.0]
+    # `warn = false`: the offset-copy warning is expected here and is asserted separately in
+    # the "Offset data emits a `warn`-gated copy warning (batch)" testitem below. This testitem
+    # only checks inference correctness, so the warning is suppressed to keep CI logs clean.
     check(model, ydata, observed) = begin
         q = last(
-            infer(model = model, data = (y = ydata,), iterations = 1).posteriors[:x],
+            infer(
+                model = model,
+                data = (y = ydata,),
+                iterations = 1,
+                warn = false,
+            ).posteriors[:x],
         )
         @test isapprox(precision(q), 1 / 100 + length(observed); atol = 1e-8)
         @test isapprox(weightedmean(q), sum(observed); atol = 1e-8)
@@ -216,9 +224,16 @@ end
         y[3] ~ NormalMeanVariance(x, 1.0) # y[2] (1-based) unreferenced -> sparse
     end
 
+    # `warn = false` for the same reason as above: the offset-copy warning is intentional and
+    # asserted in the dedicated warning testitem; here we only check inference correctness.
     check(ydata) = begin
         q = last(
-            infer(model = obs_sparse(), data = (y = ydata,), iterations = 1).posteriors[:x],
+            infer(
+                model = obs_sparse(),
+                data = (y = ydata,),
+                iterations = 1,
+                warn = false,
+            ).posteriors[:x],
         )
         @test isapprox(precision(q), 1 / 100 + 2; atol = 1e-8)        # two observations
         @test isapprox(weightedmean(q), 10.0 + 30.0; atol = 1e-8)     # 1st and 3rd values, 2nd ignored


### PR DESCRIPTION
## Problem

CI logs contain five copies of:

```
┌ Warning: Conditioned data `y` uses non-standard (offset) indexing and is copied to
│ standard 1-based indexing for inference — this incurs an allocation ...
└ @ RxInfer src/inference/batch.jl:256
```

This is **test noise, not a product bug**. The warning is emitted at `src/inference/batch.jl:250-258` and is gated on the `infer(...; warn)` keyword (default `true`) — it is working as designed.

The five messages come from two testitems in `test/inference/sparse_data_tests.jl` that deliberately condition on `OffsetArray` data but call `infer` without `warn = false`:

| Testitem | Offset invocations |
|---|---|
| `"Conditioning on offset-indexed (OffsetArray) data with 1-based model indexing"` | 3 |
| `"Offset-indexed data combined with sparse (partial) referencing"` | 2 |

3 + 2 = 5, exactly matching CI.

## Fix

The warning *behaviour* is already asserted by two dedicated testitems that capture logs with `Test.collect_test_logs` — `"Offset data emits a `warn`-gated copy warning (batch)"` and `"... (streaming, sparse var)"` — each checking that the warning fires for offset data with `warn = true`, does not fire for 1-based data, and is suppressed by `warn = false`. So no new assertion is needed.

This PR only passes `warn = false` in the two correctness-only testitems, with a comment pointing at the testitem that owns the warning assertion. This matches the existing `infer(...; warn = false)` idiom already used in `test/inference/inference_tests.jl`.

Test-only change: no source changes, no user-visible behaviour change, no CHANGELOG entry.

## Verification

```
RUN_AQUA=false julia -e 'import Pkg; Pkg.activate("."); Pkg.test(test_args = ["inference:sparse_data_tests.jl"])'
```

All 54 tests pass, including both warning-assertion testitems, and no offset warning reaches stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)