### PR TITLE
Fix unhelpful MethodError for AutoProposal sample-list with no proposal candidate (#681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `SampleListFormConstraint` with the `AutoProposal` strategy now raises an actionable error (pointing the user at `LeftProposal`/`RightProposal`) when neither operand of the product is a low-priority proposal candidate, instead of falling through to a cryptic `MethodError`. Added a regression test. ([#681](https://github.com/ReactiveBayes/RxInfer.jl/issues/681))
+
 ## [5.5.1] - 2026-08-12
 
 ### Added

--- a/src/constraints/form/form_sample_list.jl
+++ b/src/constraints/form/form_sample_list.jl
@@ -92,6 +92,18 @@ function __approximate(
     )
 end
 
+# Fallback for `AutoProposal` when neither operand is a low-priority candidate.
+# In this case the strategy has no basis to prefer one side as the proposal, so
+# we raise the same actionable error as the both-low-priority case instead of
+# letting Julia surface a cryptic `MethodError`.
+function __approximate(
+    constraint::SampleListFormConstraint{N, R, S, M}, left, right
+) where {N, R, S <: AutoProposal, M}
+    return error(
+        "Cannot approximate the product of $(left) and $(right) as a sample list. The `AutoProposal` strategy cannot choose a proposal distribution. Use either `LeftProposal` or `RightProposal` in the sample list form constraint specification.",
+    )
+end
+
 function ReactiveMP.constrain_form(::SampleListFormConstraint, something)
     return something
 end

--- a/test/constraints/form/form_sample_list_tests.jl
+++ b/test/constraints/form/form_sample_list_tests.jl
@@ -68,7 +68,7 @@
 
         # Two non-low-priority operands (neither is an `AbstractContinuousGenericLogPdf`
         # nor a `LinearizedProductOf`), so `AutoProposal` cannot pick a proposal side.
-        left  = NormalMeanVariance(0.0, 1.0)
+        left = NormalMeanVariance(0.0, 1.0)
         right = NormalMeanVariance(1.0, 2.0)
         product = ProductOf(left, right)
 

--- a/test/constraints/form/form_sample_list_tests.jl
+++ b/test/constraints/form/form_sample_list_tests.jl
@@ -62,4 +62,22 @@
         q = constrain_form(constraint, prod(GenericProd(), left, right))
         @test q isa SampleList
     end
+
+    @testset "AutoProposal raises a helpful error when neither operand is a low-priority candidate (issue #681)" begin
+        import BayesBase: ProductOf
+
+        # Two non-low-priority operands (neither is an `AbstractContinuousGenericLogPdf`
+        # nor a `LinearizedProductOf`), so `AutoProposal` cannot pick a proposal side.
+        left  = NormalMeanVariance(0.0, 1.0)
+        right = NormalMeanVariance(1.0, 2.0)
+        product = ProductOf(left, right)
+
+        constraint = SampleListFormConstraint(100) # defaults to `AutoProposal`
+
+        # Previously this fell through to a cryptic `MethodError`; it must now raise the
+        # actionable error pointing the user at `LeftProposal`/`RightProposal`.
+        @test_throws "The `AutoProposal` strategy cannot choose a proposal distribution" constrain_form(
+            constraint, product
+        )
+    end
 end


### PR DESCRIPTION
Fixes #681.

## Problem

`__approximate` for `SampleListFormConstraint{..., AutoProposal}` had three methods, all scoped to the `AutoProposalLowPriorityCandidates` union (`AbstractContinuousGenericLogPdf`, `LinearizedProductOf`):

- `left::LowPriority, right`
- `left, right::LowPriority`
- `left::LowPriority, right::LowPriority` (helpful error)

When **both** operands are **non-low-priority**, none of these match, `LeftProposal`/`RightProposal` methods don't apply (`S <: AutoProposal`), and Julia falls through to a cryptic `MethodError` with no guidance.

## Fix

Add a generic `AutoProposal` fallback that raises the same actionable error as the both-low-priority case, telling the user to pick `LeftProposal`/`RightProposal`. It is strictly less specific than the existing methods, so it never shadows them.

Adds a regression test in `test/constraints/form/form_sample_list_tests.jl` for the two-non-low-priority case.

## Testing

`test/constraints/form/form_sample_list_tests.jl` passes (98/98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)