### PR TITLE
Default SampleListFormConstraint rng to Random.default_rng() (#684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `SampleListFormConstraint` now defaults its random number generator to `Random.default_rng()` instead of the legacy `Random.GLOBAL_RNG`, and the `rng` argument (with reproducibility guidance) is now documented in the docstring. Users can still pass an explicit seeded generator as the first constructor argument for reproducible sample-list approximations. ([#684](https://github.com/ReactiveBayes/RxInfer.jl/issues/684))
+
 ## [5.5.1] - 2026-08-12
 
 ### Added

--- a/src/constraints/form/form_sample_list.jl
+++ b/src/constraints/form/form_sample_list.jl
@@ -25,6 +25,21 @@ struct AutoProposal end
     SampleListFormConstraint([rng], nsamples, strategy, method)
 
 One of the form constraint objects. Approximates `ProductOf` with a `SampleList` object.
+
+# Arguments
+
+- `rng`: (optional) random number generator used to draw the samples. Defaults to
+  `Random.default_rng()`. Pass an explicit, seeded generator (e.g. `MersenneTwister(42)`
+  or a `StableRNG`) to obtain reproducible sample-list approximations.
+- `nsamples`: number of samples in the resulting `SampleList`.
+- `strategy`: proposal selection strategy, one of [`AutoProposal`](@ref), [`LeftProposal`](@ref)
+  or [`RightProposal`](@ref). Defaults to `AutoProposal()`.
+- `method`: sampling method. Defaults to `BootstrapImportanceSampling()`.
+
+!!! note
+    When no `rng` is provided the constraint uses `Random.default_rng()`, so the drawn
+    samples depend on the global RNG state. For reproducible inference either seed the
+    global RNG with `Random.seed!` or pass an explicit `rng` as the first argument.
 """
 struct SampleListFormConstraint{N, R, S, M} <: AbstractFormConstraint
     rng      :: R
@@ -43,7 +58,7 @@ Base.show(io::IO, constraint::SampleListFormConstraint) = print(
     ")",
 )
 
-SampleListFormConstraint(nsamples::Int, strategy::S = AutoProposal(), method::M = BootstrapImportanceSampling()) where {S, M}                           = SampleListFormConstraint(Random.GLOBAL_RNG, nsamples, strategy, method)
+SampleListFormConstraint(nsamples::Int, strategy::S = AutoProposal(), method::M = BootstrapImportanceSampling()) where {S, M}                           = SampleListFormConstraint(Random.default_rng(), nsamples, strategy, method)
 SampleListFormConstraint(rng::R, nsamples::Int, strategy::S = AutoProposal(), method::M = BootstrapImportanceSampling()) where {R <: AbstractRNG, S, M} = SampleListFormConstraint{nsamples, R, S, M}(rng, strategy, method)
 
 ReactiveMP.default_form_check_strategy(::SampleListFormConstraint) =


### PR DESCRIPTION
Fixes #684.

## Problem

The convenience constructor `SampleListFormConstraint(nsamples, ...)` defaulted its RNG to `Random.GLOBAL_RNG`, which is the legacy alias. The RNG argument and its reproducibility implications were also undocumented.

## Fix

- Default to `Random.default_rng()` — the modern task-local default generator.
- Document the `rng` argument, its default, and reproducibility guidance (pass an explicit seeded generator, or seed the global RNG via `Random.seed!`) in the docstring.

Users who need fully reproducible sample-list approximations can still pass an explicit seeded generator as the first constructor argument, e.g. `SampleListFormConstraint(MersenneTwister(42), nsamples)`.

## Testing

`test/constraints/form/form_sample_list_tests.jl` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)