### PR TITLE
Replace tautological @test true with real assertions in static-inputs test (#680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Replaced the tautological `@test true` placeholder at the end of the nonlinear static-inputs model test with meaningful assertions. The inference helpers now return their collected results, and the test asserts each run produced finite posterior means/variances and finite free energy. ([#680](https://github.com/ReactiveBayes/RxInfer.jl/issues/680))
+
 ## [5.5.1] - 2026-08-12
 
 ### Added

--- a/test/models/nonlinear/static_inputs_tests.jl
+++ b/test/models/nonlinear/static_inputs_tests.jl
@@ -66,6 +66,8 @@
             @test mean(d.posteriors[:x]) ≈ mean(c.posteriors[:x])
             @test d.free_energy == c.free_energy
         end
+
+        return (datavar_based, constvar_based)
     end
 
     function inference_2inputs_x_fixed(data, x)
@@ -99,13 +101,21 @@
             @test mean(d.posteriors[:θ]) ≈ mean(c.posteriors[:θ])
             @test d.free_energy == c.free_energy
         end
+
+        return (datavar_based, constvar_based)
     end
 
-    # Inference execution
-    inference_2inputs_θ_fixed(4.0, [1.0, 2.0])
-    inference_2inputs_x_fixed(4.0, [1.0, 2.0])
+    # Inference execution. Each helper runs its own internal `@test` comparisons
+    # (datavar- vs constvar-based models) and returns the collected results so we
+    # can additionally assert the inference produced finite, sane posteriors.
+    results_θ_fixed = inference_2inputs_θ_fixed(4.0, [1.0, 2.0])
+    results_x_fixed = inference_2inputs_x_fixed(4.0, [1.0, 2.0])
 
-    # All models have been created and runned extra tests inside. 
-    # The inference finished without errors
-    @test true
+    for (datavar_based, constvar_based) in (results_θ_fixed, results_x_fixed)
+        for result in Iterators.flatten((datavar_based, constvar_based))
+            @test all(isfinite, mean(result.posteriors[:z]))
+            @test all(isfinite, var(result.posteriors[:z]))
+            @test all(isfinite, result.free_energy)
+        end
+    end
 end


### PR DESCRIPTION
Fixes #680.

## Problem

`test/models/nonlinear/static_inputs_tests.jl` ended with a bare `@test true` placeholder, which can never fail and asserts nothing.

Note: the premise in the issue is only partly accurate — the two inference helpers (`inference_2inputs_θ_fixed` / `inference_2inputs_x_fixed`) *do* contain real `@test` comparisons internally (datavar- vs constvar-based models), so coverage was not zero. But the trailing `@test true` itself contributed nothing.

## Fix

- The helpers now `return (datavar_based, constvar_based)`.
- The test asserts each of the 8 inference runs produced finite posterior mean/variance for `:z` and finite free energy, in addition to the existing internal comparisons.

## Testing

`test/models/nonlinear/static_inputs_tests.jl` passes (88/88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)